### PR TITLE
Release 0.1.a (#1)

### DIFF
--- a/Content/Icons/SimpleTemplate_16x.png
+++ b/Content/Icons/SimpleTemplate_16x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f74d3c111b98b6fed36d0cdf2b93c43227dfe6676aebe4e29d62ec23472ac404
+size 815

--- a/Content/Icons/SimpleTemplate_64x.png
+++ b/Content/Icons/SimpleTemplate_64x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77226d95984d4bab5be9f5c1d4794b13fabaca95dd4349e48ce07fb52977c1af
+size 5193

--- a/Content/Icons/icon_compile_40x.png
+++ b/Content/Icons/icon_compile_40x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34c23c9e6158f4224fe3c185ceb7fa2546ccdb3de27343dc817b3eac5966707c
+size 2662

--- a/Content/Icons/icon_compile_dirty_40x.png
+++ b/Content/Icons/icon_compile_dirty_40x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:247bf502fb66b9d197b6c089c10f360bad74354b756c71b80ccf27bdc7762a0c
+size 2682

--- a/Content/Icons/icon_compile_error_40x.png
+++ b/Content/Icons/icon_compile_error_40x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a678fe70f95fe566c058a0acdef660ed3ba230ffbab3b56781fd7f8f355906e
+size 2736

--- a/Content/Icons/icon_export_40x.png
+++ b/Content/Icons/icon_export_40x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a7b03568132f58a89d765ed44fc25776715b301d943e4ce035de623ae2318ec
+size 2555

--- a/Content/Icons/icon_import_40x.png
+++ b/Content/Icons/icon_import_40x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eb9f4f2b4e015dfff5291a06396fe25a28c0361162b08e634fef45dbba84b27
+size 3474

--- a/README.md
+++ b/README.md
@@ -1,7 +1,55 @@
-# Simple Template Engine
+# Simple Template
 
 Text based template engine with logic. Templates are compiled for better reuse and 
 faster runtime usage.
+
+## Install
+
+Clone the whole repo into your local game `Plugins` folder or your engines `Plugins` folder.
+
+TODO: Add some more info to make it easy, plus some precompiled binaries ^^.
+
+## Templates
+
+Templates are simple text files with a special syntax to define your needs. While simple it is yet quite powerful.
+
+### Syntax
+
+> {$VariableName}
+
+Create a variable token. The name of the variable itself will be the key the interpreter will use to find the right data.
+
+> {% for Item in ListKey %}Item: {$item}{% endfor %}
+
+Will iterate a list list value that is stored in a key called `ListKey`. `Item` represents the element that we iterate. As you can see we print out the value of item using a variable token. Again, both `ListKey` and `Item` are keys use to look up for data.
+
+The list iterator provides the index if needed, just use the `{$loop.index}` variable to use if your templates.
+
+> {% if Engine == "UE4" %}Engine: Unreal Engine 4{% endif %}
+
+A simple branch statement, you can either use literals as shown in the example or other keys. If the key is of boolean value you can even just use it for the branch. `==`, `!=` or `~=` are valid condition modiefiers. `~=` is used for special non-casesentitive conditions.
+
+### Compiling
+
+TODO: Just the whole process I guess xD
+
+### Interpeting
+
+Interpreting a template is quite simple, you can ither use a compiled template asset `USimpleTemplate` and call it's `FString Interpret(TScriptInterface<ISimpleTemplateDataProvider> DataProvider)` method or directly from a string.
+
+A `ISimpleTemplateDataProvider` is just the interface you use to provide the engine with the needed data in JSON format. `USimpleTemplateData` is a the default data provider that comes out-of-the-box.
+
+TODO: Low level stuff
+
+## Usage
+
+Once you have your templates setup you can use them either in C++ or in Blueprint using the provided function library.
+
+TODO: Finish integrations and add documention
+
+## Examples
+
+TODO: Add some examples and screen shots
 
 License
 ----
@@ -33,4 +81,4 @@ Legal info
 
 Unreal® is a trademark or registered trademark of Epic Games, Inc. in the United States of America and elsewhere.
 
-Unreal® Engine, Copyright 1998 – 2014, Epic Games, Inc. All rights reserved.
+Unreal® Engine, Copyright 1998 – 2017, Epic Games, Inc. All rights reserved.

--- a/Resources/Icon128.png
+++ b/Resources/Icon128.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f7369a38ebea40bc847a4a228b0d34981c0d60c55ff54ac603ee194ec2d785c
+size 11769

--- a/Resources/UI/TextEditorBorder.png
+++ b/Resources/UI/TextEditorBorder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e793639f2ab6c44edf66008b524d61ece67ca2fe6656ffb3fd95168ec6d428
+size 2828

--- a/SimpleTemplate.uplugin
+++ b/SimpleTemplate.uplugin
@@ -1,0 +1,32 @@
+{
+	"FileVersion" : 3,
+	"Version" : 7,
+	"VersionName" : "7.0",
+	"EngineVersion" : "4.17.0",
+	"FriendlyName" : "Simple Templat",
+	"Description" : "Adds an editable text content asset for personal notes.",
+	"Category" : "Editor",
+	"CreatedBy" : "Epic Games Inc",
+	"CreatedByURL" : "http://epicgames.com",
+	"DocsURL" : "",
+	"MarketplaceURL" : "",
+	"SupportURL" : "",
+	"EnabledByDefault" : true,
+	"CanContainContent" : false,
+	"IsBetaVersion" : false,
+	"Installed" : false,
+	"Modules" :
+	[
+		{
+			"Name" : "SimpleTemplate",
+			"Type" : "Runtime",
+			"LoadingPhase" : "Default"
+		},
+		{
+			"Name" : "SimpleTemplateEditor",
+			"Type" : "Editor",
+			"LoadingPhase" : "Default"
+		}
+
+	]
+}

--- a/Source/SimpleTemplate/Private/Compiler/SimpleTemplateCompiler.cpp
+++ b/Source/SimpleTemplate/Private/Compiler/SimpleTemplateCompiler.cpp
@@ -1,0 +1,55 @@
+// Copyright Playspace S.L. 2017
+
+#include "Compiler/SimpleTemplateCompiler.h"
+
+void FTokenArray::Serialize(FArchive& Ar)
+{
+	int32 NumTokens = Items.Num();
+	Ar << NumTokens;
+	if (Ar.IsLoading())
+	{
+		while (NumTokens > 0)
+		{
+			--NumTokens;
+
+			ETokenType TokenType;
+			Ar << TokenType;
+
+			FToken* token = nullptr;
+			switch (TokenType)
+			{
+			case ETokenType::Text:
+				token = new FTokenText();
+				break;
+			case ETokenType::Var:
+				token = new FTokenVar();
+				break;
+			case ETokenType::If:
+				token = new FTokenIf();
+				break;
+			case ETokenType::For:
+				token = new FTokenFor();
+				break;
+			case ETokenType::EndIf:
+				token = new FTokenEndIf();
+				break;
+			case ETokenType::EndFor:
+				token = new FTokenEndFor();
+				break;
+			}
+
+			token->Serialize(Ar);
+			Items.Add(MakeShareable(token));
+		}
+	}
+	else
+	{
+		for (auto Token : Items)
+		{
+			// Always add the type first
+			ETokenType serializedType = Token->GetType();
+			Ar << serializedType;
+			Token->Serialize(Ar);
+		}
+	}
+}

--- a/Source/SimpleTemplate/Private/Interfaces/SimpleTemplateDataProvider.cpp
+++ b/Source/SimpleTemplate/Private/Interfaces/SimpleTemplateDataProvider.cpp
@@ -1,0 +1,8 @@
+// Copyright Playspace S.L. 2017
+
+#include "Interfaces/SimpleTemplateDataProvider.h"
+
+USimpleTemplateDataProvider::USimpleTemplateDataProvider(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer)
+{
+}

--- a/Source/SimpleTemplate/Private/Kismet/SimpleTemplateLibrary.cpp
+++ b/Source/SimpleTemplate/Private/Kismet/SimpleTemplateLibrary.cpp
@@ -1,0 +1,15 @@
+// Copyright Playspace S.L. 2017
+
+#include "Kismet/SimpleTemplateLibrary.h"
+
+FString USimpleTemplateLibrary::Interpret(USimpleTemplate* SimpleTemplate, TScriptInterface<ISimpleTemplateDataProvider> DataProvider)
+{
+	return SimpleTemplate->Interpret(DataProvider);
+}
+
+USimpleTemplateData* USimpleTemplateLibrary::NewDataProvider(const FString& Data)
+{
+	USimpleTemplateData* DataProvider = NewObject<USimpleTemplateData>();
+	DataProvider->SetData(Data);
+	return DataProvider;
+}

--- a/Source/SimpleTemplate/Private/SimpleTemplate.cpp
+++ b/Source/SimpleTemplate/Private/SimpleTemplate.cpp
@@ -1,0 +1,79 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplate.h"
+
+DEFINE_LOG_CATEGORY(LogSTE);
+
+void USimpleTemplate::Serialize(FArchive& Ar)
+{
+	Super::Serialize(Ar);
+
+	// Serialize token array
+	if (Ar.IsLoading())
+	{
+		uint32 TemplateVersion;
+		Ar << TemplateVersion;
+		if (TemplateVersion != TPL_VERSION)
+		{
+			UE_LOG(LogSTE, Error, TEXT("Serialized template version is incompatible with your current version! Need to recompile!"));
+			Status = ETemplateStatus::TS_Dirty;
+		}
+		Tokens.Serialize(Ar);
+	}
+	else if (Ar.IsSaving())
+	{
+		Ar << TPL_VERSION;
+		Tokens.Serialize(Ar);
+	}
+}
+
+FString USimpleTemplate::Interpret(TScriptInterface<ISimpleTemplateDataProvider> DataProvider)
+{
+	if (IsUpToDate())
+	{
+		auto interpreter = TTemplateInterpreter::Create(Tokens);
+		FString OutString;
+		if (interpreter->Interpret(OutString, DataProvider))
+		{
+			return OutString;
+		}
+	}
+	return FString();
+}
+
+#if WITH_EDITOR
+
+void USimpleTemplate::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	const FName PropertyName = (PropertyChangedEvent.Property ? PropertyChangedEvent.Property->GetFName() : NAME_None);
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(USimpleTemplate, Template))
+	{
+		Status = ETemplateStatus::TS_Dirty;
+	}
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+}
+
+bool USimpleTemplate::Compile()
+{
+	LineNumber = 0;
+	CharacterNumber = 0;
+	LastErrors.Empty();
+	auto compiler = TTemplateCompilerFactory<TCHAR>::Create(Template.ToString());
+	if (compiler->Compile())
+	{
+		Tokens = compiler->GetTokenTree();
+		Status = ETemplateStatus::TS_UpToDate;
+		PostEditChange();
+		MarkPackageDirty();
+		return true;
+	}
+	LineNumber = compiler->GetLineNumber();
+	CharacterNumber = compiler->GetCharNumber();
+	LastErrors.Add(compiler->GetLastError());
+	Status = ETemplateStatus::TS_Error;
+	PostEditChange();
+	MarkPackageDirty();
+	return false;
+}
+
+#endif

--- a/Source/SimpleTemplate/Private/SimpleTemplateData.cpp
+++ b/Source/SimpleTemplate/Private/SimpleTemplateData.cpp
@@ -1,0 +1,37 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplateData.h"
+#include "SimpleTemplate.h"
+
+USimpleTemplateData::USimpleTemplateData()
+    : Super()
+{
+    JsonPtr = MakeShareable(new FJsonObject());
+	SetData(Json);
+}
+
+bool USimpleTemplateData::SetData(const FString& Data)
+{
+	if (JsonString.Equals(Data))
+	{
+		return true;
+	}
+	JsonString = JsonString;
+	auto Reader = TJsonReaderFactory<>::Create(*Data);
+	if (FJsonSerializer::Deserialize(Reader, JsonPtr) && JsonPtr.IsValid())
+	{
+		return true;
+	}
+	if (JsonPtr.IsValid())
+	{
+		JsonPtr.Reset();
+	}
+	JsonPtr = MakeShareable(new FJsonObject());
+	UE_LOG(LogSTE, Error, TEXT("Failed to decode Object from JSON string for: %s"), *JsonString);
+	return false;
+}
+
+TSharedPtr<FJsonObject> USimpleTemplateData::GetData() const
+{
+    return JsonPtr;
+}

--- a/Source/SimpleTemplate/Private/SimpleTemplateModule.cpp
+++ b/Source/SimpleTemplate/Private/SimpleTemplateModule.cpp
@@ -1,0 +1,27 @@
+// Copyright Playspace S.L. 2017
+
+#include "Modules/ModuleInterface.h"
+#include "Modules/ModuleManager.h"
+
+
+/**
+ * Implements the SimpleTemplate module.
+ */
+class FSimpleTemplateModule
+	: public IModuleInterface
+{
+public:
+
+	//~ IModuleInterface interface
+
+	virtual void StartupModule() override { }
+	virtual void ShutdownModule() override { }
+
+	virtual bool SupportsDynamicReloading() override
+	{
+		return true;
+	}
+};
+
+
+IMPLEMENT_MODULE(FSimpleTemplateModule, SimpleTemplate);

--- a/Source/SimpleTemplate/Public/Compiler/SimpleTemplateCompiler.h
+++ b/Source/SimpleTemplate/Public/Compiler/SimpleTemplateCompiler.h
@@ -1,0 +1,962 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/ObjectMacros.h"
+#include "UObject/Object.h"
+#include "Dom/JsonValue.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonTypes.h"
+#include "Serialization/BufferReader.h"
+#include "Serialization/MemoryWriter.h"
+#include "Interfaces/SimpleTemplateDataProvider.h"
+
+#include "SimpleTemplateCompiler.generated.h"
+
+// Static tokens
+static FString TPL_START_TOKEN(TEXT("{"));
+static FString TPL_END_TOKEN(TEXT("}"));
+static FString TPL_START_IF_TOKEN(TEXT("if"));
+static FString TPL_END_IF_TOKEN(TEXT("endif"));
+static FString TPL_START_FOR_TOKEN(TEXT("for"));
+static FString TPL_END_FOR_TOKEN(TEXT("endfor"));
+
+// The template serialization version
+static uint32 TPL_VERSION = 1;
+
+class TTemplateCompilerHelper
+{
+public:
+	static TSharedPtr<FJsonValue> GetValue(FString& Key, TSharedPtr<FJsonObject> Data)
+	{
+		if (Data.IsValid() && !Key.IsEmpty())
+		{
+			TArray<FString> KeyList;
+			Key.ParseIntoArray(KeyList, TEXT("."), true);
+
+			TSharedPtr<FJsonValue> CurrentValue = nullptr;
+			TSharedPtr<FJsonObject> CurrentObject = Data;
+			for (auto i = 0; i < KeyList.Num(); i++)
+			{
+				auto CurrentKey = KeyList[i];
+
+				// Get field
+				CurrentValue = CurrentObject->TryGetField(CurrentKey);
+				if (!CurrentValue.IsValid())
+				{
+					return nullptr;
+				}
+
+				// Prepare for next field
+				if (i < KeyList.Num() - 1)
+				{
+					// Get next
+					CurrentObject = CurrentValue->AsObject();
+					if (!CurrentObject.IsValid())
+					{
+						return nullptr;
+					}
+				}
+			}
+			return CurrentValue;
+		}
+		return nullptr;
+	}
+};
+
+//
+// Tokens
+//
+
+/** Tokens our template engine can parse */
+UENUM()
+enum class ETokenType : uint8
+{
+    None,
+    Text,
+    Var,
+    If,
+    For,
+    EndIf,
+    EndFor
+};
+
+class SIMPLETEMPLATE_API FToken
+{
+public:
+	FToken() {}
+
+    virtual ~FToken() {}
+
+	virtual ETokenType GetType() const
+	{
+		return ETokenType::None;
+	}
+
+	virtual FString Build()
+	{
+		return FString();
+	}
+	
+	virtual void Serialize(FArchive& Ar) {}
+
+	// Interpret the token 
+	virtual void Interpret(FArchive& WriteStream, TSharedPtr<FJsonObject> Data) {}
+
+	// Some tokens are nested
+	virtual void SetChildren(TArray<TSharedPtr<FToken>>& children) {}
+	virtual TArray<TSharedPtr<FToken>>* GetChildren() { return nullptr; }
+};
+
+typedef TSharedPtr<FToken> FTokenPtr;
+
+USTRUCT(Blueprintable)
+struct SIMPLETEMPLATE_API FTokenArray
+{
+	GENERATED_USTRUCT_BODY()
+
+public:
+
+	void Serialize(FArchive& Ar);
+
+public:
+	TArray<FTokenPtr> Items;
+};
+
+class SIMPLETEMPLATE_API FTokenText : public FToken
+{
+public:
+	FTokenText() : FToken() {}
+
+    FTokenText(const FString& InText)
+        : FToken()
+		, Text(InText)
+	{}
+
+    ETokenType GetType() const override
+    {
+        return ETokenType::Text;
+    }
+
+	virtual void Serialize(FArchive& Ar) override
+	{
+		Ar << Text;
+	}
+
+	virtual void Interpret(FArchive& WriteStream, TSharedPtr<FJsonObject> Data) override
+	{
+		WriteStream.Serialize((void*)*Text, Text.Len() * sizeof(TCHAR));
+	}
+
+public:
+	FString Text;
+};
+
+class SIMPLETEMPLATE_API FTokenVar : public FToken
+{
+public:
+	FTokenVar() : FToken() {}
+
+	FTokenVar(const FString& InKey)
+		: FToken()
+		, Key(InKey)
+	{}
+
+	virtual FString Build() override
+	{
+		return FString();
+	}
+
+	ETokenType GetType() const override
+	{
+		return ETokenType::Var;
+	}
+
+	virtual void Serialize(FArchive& Ar) override
+	{
+		Ar << Key;
+	}
+
+	virtual void Interpret(FArchive& WriteStream, TSharedPtr<FJsonObject> Data) override
+	{
+		auto value = TTemplateCompilerHelper::GetValue(Key, Data);
+		FString valueStr;
+		if (value.IsValid() && value->TryGetString(valueStr))
+		{
+			WriteStream.Serialize((void*)*valueStr, valueStr.Len() * sizeof(TCHAR));
+		}
+	}
+
+public:
+	FString Key;
+};
+
+class SIMPLETEMPLATE_API FTokenNested : public FToken
+{
+public:
+	FTokenNested() : FToken() {}
+
+	FTokenNested(const FString& InExpression)
+		: FToken()
+		, Expression(InExpression)
+	{}
+
+	virtual void Serialize(FArchive& Ar) override
+	{
+		Ar << Expression;
+		Children.Serialize(Ar);
+	}
+
+	// Some tokens are nested
+	virtual void SetChildren(TArray<TSharedPtr<FToken>>& children)
+	{
+		Children.Items = children;
+	}
+
+	virtual TArray<TSharedPtr<FToken>>* GetChildren()
+	{
+		return &Children.Items;
+	}
+
+public:
+	FString Expression;
+	FTokenArray Children;
+};
+
+class SIMPLETEMPLATE_API FTokenFor : public FTokenNested
+{
+public:
+	FTokenFor() : FTokenNested() {}
+
+	FTokenFor(const FString& Expresion)
+		: FTokenNested(Expresion)
+	{
+	}
+
+	virtual FString Build() override
+	{
+		TArray<FString> ForValues;
+		Expression.ParseIntoArray(ForValues, TEXT(" "));
+		// Expresion must be: for key in value
+		if (ForValues.Num() != 4 || !ForValues[2].Equals("in"))
+		{
+			return FString::Printf(TEXT("'for' token must in form of: for key in value. '%s' found instead"), *Expression);
+		}
+		Value = ForValues[1];
+		List = ForValues[3];
+		return FString();
+	}
+
+	virtual void Interpret(FArchive& WriteStream, TSharedPtr<FJsonObject> Data) override
+	{
+		auto listDataPtr = TTemplateCompilerHelper::GetValue(List, Data);
+		const TArray<TSharedPtr<FJsonValue>>* list;
+		if (listDataPtr->TryGetArray(list))
+		{
+			for (int i = 0; i < list->Num(); i++)
+			{
+				// Add loop data
+				// loop.index
+				TSharedPtr<FJsonObject> loopData = MakeShareable(new FJsonObject());
+				loopData->SetNumberField("index", i);
+				Data->SetObjectField("loop", loopData);
+
+				// Set item
+				auto item = (*list)[0];
+				Data->SetField(Value, item);
+
+				// Now propagate
+				for (auto child : Children.Items)
+				{
+					child->Interpret(WriteStream, Data);
+				}
+			}
+		}
+	}
+
+    ETokenType GetType() const override
+    {
+        return ETokenType::For;
+    }
+
+	virtual void Serialize(FArchive& Ar) override
+	{
+		FTokenNested::Serialize(Ar);
+		Ar << List;
+		Ar << Value;
+	}
+
+public:
+	FString List;
+	FString Value;
+};
+
+class SIMPLETEMPLATE_API FTokenIf : public FTokenNested
+{
+public:
+	FTokenIf() : FTokenNested() {}
+
+	FTokenIf(const FString& Expresion)
+		: FTokenNested(Expresion) {}
+
+
+	virtual FString Build() override
+	{
+		TArray<FString> IfValues;
+		Expression.ParseIntoArray(IfValues, TEXT(" "));
+
+		// Parse sign
+
+		if (IfValues.Num() < 2)
+		{
+			return FString::Printf(TEXT("'if' token is not a boolean operation. '{%s}' found instead."), *Expression);
+		}
+
+		// if not var
+		if (IfValues[1].Equals("not") || IfValues[1].Equals("!"))
+		{
+			bSign = false;
+			Key = IfValues[2];
+		}
+		// if var
+		else if (IfValues.Num() == 2)
+		{
+			Key = IfValues[1];
+		}
+		// if var == value | if var != value
+		else
+		{
+			if (IfValues[2].Equals("==") | IfValues[2].Equals("!=") || IfValues[2].Equals("~="))
+			{
+				bSign = IfValues[2].Equals("==") || IfValues[2].Equals("~=");
+				bIgnoreCase = IfValues[2].Equals("~=");
+			}
+			else
+			{
+				return FString::Printf(TEXT("'if' boolean operation can either be '==' or '!='. '%s' found instead."), *Expression);
+			}
+			
+			Key = IfValues[1];
+			Value = IfValues[3];
+		}
+		return FString();
+	}
+
+	virtual void Interpret(FArchive& WriteStream, TSharedPtr<FJsonObject> Data) override
+	{
+		if (IsTrue(Data))
+		{
+			for(auto child : Children.Items)
+			{
+				child->Interpret(WriteStream, Data);
+			}
+		}
+	}
+
+    ETokenType GetType() const override
+    {
+        return ETokenType::If;
+    }
+
+	virtual void Serialize(FArchive& Ar) override
+	{
+		FTokenNested::Serialize(Ar);
+		bool bAux;
+		Ar << bAux;
+		bSign = bAux;
+		Ar << bAux;
+		bIgnoreCase = bAux;
+		Ar << Key;
+		Ar << Value;
+	}
+
+private:
+	bool IsTrue(TSharedPtr<FJsonObject> Data)
+	{
+		// Only key provided
+		if (Value.IsEmpty())
+		{
+			bool boolValue = false;
+			auto keyDataPtr = TTemplateCompilerHelper::GetValue(Key, Data);
+			return keyDataPtr.IsValid() && keyDataPtr->TryGetBool(boolValue) && (boolValue == bSign);
+		}
+
+		// Find l-value and r-value
+		auto lValuePtr = TTemplateCompilerHelper::GetValue(Key, Data);
+		auto rValuePtr = TTemplateCompilerHelper::GetValue(Value, Data);
+		if (!rValuePtr.IsValid())
+		{
+			rValuePtr = MakeShareable(new FJsonValueString(Value.TrimQuotes()));
+		}
+
+		// Compare
+		FString lValue;
+		FString rValue;
+		return lValuePtr->TryGetString(lValue) && rValuePtr->TryGetString(rValue) && (lValue.Equals(rValue, bIgnoreCase ? ESearchCase::IgnoreCase : ESearchCase::CaseSensitive) == bSign);
+	}
+
+public:
+	uint32 bSign : 1;
+	uint32 bIgnoreCase : 1;
+	FString Key;
+	FString Value;
+};
+
+class SIMPLETEMPLATE_API FTokenEnd : public FToken
+{
+public:
+	FTokenEnd() : FToken() {}
+
+	FTokenEnd(const FString& InExpression)
+		: FToken()
+		, Expression(InExpression)
+	{}
+
+	virtual void Serialize(FArchive& Ar) override
+	{
+		Ar << Expression;
+	}
+
+public:
+	FString Expression;
+};
+
+class SIMPLETEMPLATE_API FTokenEndIf : public FTokenEnd
+{
+public:
+	FTokenEndIf() : FTokenEnd() {}
+
+	FTokenEndIf(const FString& Expresion)
+		: FTokenEnd(Expresion) {}
+
+
+	virtual FString Build() override
+	{
+		if (!Expression.Equals(TPL_END_IF_TOKEN, ESearchCase::IgnoreCase))
+		{
+			return FString::Printf(TEXT("'%s' token expected. '%s' found instead."), *TPL_END_IF_TOKEN, *Expression);
+		}
+		return FString();
+	}
+
+	ETokenType GetType() const override
+	{
+		return ETokenType::EndIf;
+	}
+};
+
+class SIMPLETEMPLATE_API FTokenEndFor : public FTokenEnd
+{
+public:
+	FTokenEndFor() : FTokenEnd() {}
+
+	FTokenEndFor(const FString& Expresion)
+		: FTokenEnd(Expresion) {}
+
+	virtual FString Build() override
+	{
+		if (!Expression.Equals(TPL_END_FOR_TOKEN, ESearchCase::IgnoreCase))
+		{
+			return FString::Printf(TEXT("'%s' token expected. '%s' found instead."), *TPL_END_FOR_TOKEN, *Expression);
+		}
+		return FString();
+	}
+
+	ETokenType GetType() const override
+	{
+		return ETokenType::EndFor;
+	}
+};
+
+//
+// The template parser
+//
+template <class CharType = TCHAR>
+class SIMPLETEMPLATE_API TTemplateTokenizer
+{
+public:
+    static TSharedRef< TTemplateTokenizer<CharType>> Create(FArchive* const Stream)
+    {
+        return MakeShareable(new TTemplateTokenizer<CharType>(Stream));
+    }
+
+public:
+    virtual ~TTemplateTokenizer() {}
+
+	FTokenArray GetTokenTree()
+	{
+		return Tree;
+	}
+
+	FString GetLastError()
+	{
+		return ErrorMessage;
+	}
+
+	uint32 GetLineNumber()
+	{
+		return LineNumber;
+	}
+
+	uint32 GetCharNumber()
+	{
+		return CharNumber;
+	}
+
+	bool Compile()
+	{
+		if (bHasTokens)
+		{
+			return true;
+		}
+		bHasTokens = Tokenize();
+		if (bHasTokens)
+		{
+			Parse(Tokens, Tree, ETokenType::None);
+		}
+		return bHasTokens;
+	}
+
+protected:
+
+    /** Hidden default constructor. */
+	TTemplateTokenizer()
+		: ReadStream(nullptr)
+		, ErrorMessage()
+		, LineNumber(0)
+		, CharNumber(0)
+		, bHasTokens(false)
+	{ }
+
+	TTemplateTokenizer(FArchive* InStream)
+		: ReadStream(InStream)
+		, ErrorMessage()
+		, LineNumber(0)
+		, CharNumber(0)
+		, bHasTokens(false)
+	{ }
+
+protected:
+
+	// Current Stream
+	FArchive* ReadStream;
+    FTokenArray Tokens;
+	FTokenArray Tree;
+	TArray<ETokenType> ParseState;
+
+	// Line/Char for error tracking
+	FString ErrorMessage;
+    uint32 LineNumber;
+    uint32 CharNumber;
+
+	// Parser state
+	uint32 bHasTokens : 1;
+
+private:
+
+	// Parse the plain token list into a tree
+	void Parse(FTokenArray& tokens, FTokenArray& tree, ETokenType mark)
+	{
+		while (Tokens.Items.Num() > 0)
+		{
+			auto token = Tokens.Items[0];
+			Tokens.Items.RemoveAt(0);
+			if (token->GetType() == ETokenType::For || token->GetType() == ETokenType::If)
+			{
+				FTokenArray children;
+				Parse(tokens, children, token->GetType() == ETokenType::For ? ETokenType::EndFor : ETokenType::EndIf);
+				token->SetChildren(children.Items);
+			}
+			else if (token->GetType() == mark)
+			{
+				return;
+			}
+			tree.Items.Add(token);
+		}
+	}
+
+	// Tokenize the input stream
+	bool Tokenize()
+	{
+		if (bHasTokens)
+		{
+			return true;
+		}
+
+		ClearError();
+		if (ReadStream == nullptr)
+		{
+			SetError(TEXT("Null Stream"));
+			return false;
+		}
+
+		FString Buffer = "";
+		while (!ReadStream->AtEnd())
+		{
+			// Find start token
+			if (!NextStartToken(Buffer))
+			{
+				if (!AddToken(new FTokenText(Buffer)))
+				{
+					return false;
+				}
+				break;
+			}
+
+			// Create text token for the left part
+			if (!Buffer.IsEmpty())
+			{
+				if (!AddToken(new FTokenText(Buffer)))
+				{
+					return false;
+				}
+			}
+
+			// Reset buffer
+			Buffer = "";
+
+			// Read token
+			CharType Char;
+			if (!ReadNext(Char))
+			{
+				break;
+			}
+
+			if (IsVarToken(Char))
+			{
+				if (NextEndToken(Buffer))
+				{
+					Buffer.Trim();
+					if (!AddToken(new FTokenVar(Buffer)))
+					{
+						return false;
+					}
+					Buffer = "";
+				}
+				else
+				{
+					SetError(FString::Printf(TEXT("Missing '}' after a var token"), *TPL_END_TOKEN));
+					return false;
+				}
+			}
+			else if (IsControlToken(Char))
+			{
+				if (NextEndToken(Buffer))
+				{
+					Buffer.Trim();
+					if (Buffer.StartsWith(TPL_START_FOR_TOKEN))
+					{
+						if (!AddToken(new FTokenFor(Buffer)))
+						{
+							return false;
+						}
+						ParseState.Push(ETokenType::EndFor);
+					}
+					else if (Buffer.StartsWith(TPL_START_IF_TOKEN))
+					{
+						if (!AddToken(new FTokenIf(Buffer)))
+						{
+							return false;
+						}
+						ParseState.Push(ETokenType::EndIf);
+					}
+					else
+					{
+						Buffer.TrimTrailing();
+
+						// Check end token to match ParseState
+						ETokenType expectedToken = ParseState.Pop();
+						switch (expectedToken)
+						{
+						case ETokenType::EndIf:
+							if (!Buffer.Equals(TPL_END_IF_TOKEN, ESearchCase::IgnoreCase))
+							{
+								SetError(FString::Printf(TEXT("'%s' expected. '%s' found instead."), *TPL_END_IF_TOKEN, *Buffer));
+								return false;
+							}
+							// Add token
+							if (!AddToken(new FTokenEndIf(Buffer)))
+							{
+								return false;
+							}
+							break;
+						case ETokenType::EndFor:
+							if (!Buffer.Equals(TPL_END_FOR_TOKEN, ESearchCase::IgnoreCase))
+							{
+								SetError(FString::Printf(TEXT("'%s' expected. '%s' found instead."), *TPL_END_FOR_TOKEN, *Buffer));
+								return false;
+							}
+							// Add token
+							if (!AddToken(new FTokenEndFor(Buffer)))
+							{
+								return false;
+							}
+							break;
+						default:
+							SetError(FString::Printf(TEXT("Unexpected token '%s'."), *Buffer));
+							return false;
+							break;
+						}
+					}
+					Buffer = "";
+				}
+				else
+				{
+					SetError(FString::Printf(TEXT("Missing '%s' after control token"), *TPL_END_TOKEN));
+					return false;
+				}
+			}
+			else
+			{
+				if (!AddToken(new FTokenText(TPL_START_TOKEN)))
+				{
+					return false;
+				}
+			}
+		}
+
+		if (ParseState.Num() > 0)
+		{
+			ETokenType expectedToken = ParseState.Pop();
+			switch (expectedToken)
+			{
+			case ETokenType::EndIf:
+				SetError(FString::Printf(TEXT("Missing end token '%s' at EOF"), *TPL_END_IF_TOKEN));
+				break;
+			case ETokenType::EndFor:
+				SetError(FString::Printf(TEXT("Missing end token '%s' at EOF"), *TPL_END_FOR_TOKEN));
+				break;
+			default:
+				SetError(FString::Printf(TEXT("Missing unexpected end token")));
+				return false;
+				break;
+			}
+			return false;
+		}
+		return true;
+	}
+
+	void SetError(const FString& Error)
+	{
+		ErrorMessage = FString::Printf(TEXT("[ERROR] Line: %u Ch: %u: %s"), LineNumber, CharNumber, *Error);
+		UE_LOG(LogSTE, Error, TEXT("%s"), *ErrorMessage);
+	}
+
+	void ClearError()
+	{
+		ErrorMessage = TEXT("");
+	}
+
+	bool AddToken(FToken* token)
+	{
+		FString buildError = token->Build();
+		if (buildError.IsEmpty())
+		{
+			Tokens.Items.Add(MakeShareable(token));
+			return true;
+		}
+		SetError(buildError);
+		return false;
+	}
+
+	bool ReadNext(CharType& Char)
+	{
+		ReadStream->Serialize(&Char, sizeof(CharType));
+		++CharNumber;
+		bool readNext = !IsEOF(Char);
+		if (readNext && IsLineBreak(Char))
+		{
+			++LineNumber;
+			CharNumber = 0;
+		}
+		return readNext;
+	}
+
+	bool NextStartToken(FString& Text)
+	{
+		while (!ReadStream->AtEnd())
+		{
+			CharType Char;
+			if (!ReadNext(Char))
+			{
+				break;
+			}
+			if (IsTokenStart(Char))
+			{
+				return true;
+			}
+			Text.AppendChar(Char);
+		}
+		return false;
+	}
+
+	bool NextEndToken(FString& Text)
+	{
+		while (!ReadStream->AtEnd())
+		{
+			CharType Char;
+			if (!ReadNext(Char))
+			{
+				break;
+			}
+			if (IsTokenEnd(Char))
+			{
+				return true;
+			}
+			if (!IsControlToken(Char))
+			{
+				Text.AppendChar(Char);
+			}
+		}
+		return false;
+	}
+
+	bool IsLineBreak(const CharType& Char)
+	{
+		return Char == CharType('\n');
+	}
+	
+	bool IsEOF(const CharType& Char)
+	{
+		return Char == CharType('0');
+	}
+
+	bool IsTokenStart(const CharType& Char)
+	{
+		return Char == CharType('{');
+	}
+
+	bool IsTokenEnd(const CharType& Char)
+	{
+		return Char == CharType('}');
+	}
+
+	bool IsVarToken(const CharType& Char)
+	{
+		return Char == CharType('$');
+	}
+
+	bool IsControlToken(const CharType& Char)
+	{
+		return Char == CharType('%');
+	}
+
+};
+
+class SIMPLETEMPLATE_API FStringTemplateParser
+	: public TTemplateTokenizer<TCHAR>
+{
+public:
+
+	static TSharedRef<FStringTemplateParser> Create(const FString& JsonString)
+	{
+		return MakeShareable(new FStringTemplateParser(JsonString));
+	}
+
+public:
+
+	virtual ~FStringTemplateParser()
+	{
+		if (Reader != nullptr)
+		{
+			check(Reader->Close());
+			delete Reader;
+		}
+	}
+
+protected:
+	FStringTemplateParser(const FString& JsonString)
+		: TTemplateTokenizer<TCHAR>()
+	{
+		Reader = new FBufferReader((void*)*JsonString, JsonString.Len() * sizeof(TCHAR), false);
+		check(Reader);
+		ReadStream = Reader;
+	}
+
+protected:
+	FBufferReader* Reader;
+};
+
+//
+// Factory for easy access
+//
+
+class SIMPLETEMPLATE_API TTemplateInterpreter
+{
+public:
+
+	static TSharedRef< TTemplateInterpreter > Create(FTokenArray& TokenTree)
+	{
+		return MakeShareable(new TTemplateInterpreter(TokenTree));
+	}
+
+	// TODO: Add error handling
+
+	bool Interpret(FArchive& WriteStream, TSharedPtr<FJsonObject> Data)
+	{
+		for (auto token : TokenTree.Items)
+		{
+			token->Interpret(WriteStream, Data);
+		}
+		return true;
+	}
+
+	bool Interpret(FString& OutString, TSharedPtr<FJsonObject> Data)
+	{
+		TArray<uint8> Bytes;
+		auto WriteStream = new FMemoryWriter(Bytes);
+
+		if (Interpret(*WriteStream, Data))
+		{
+
+			FString Out;
+			for (int32 i = 0; i < Bytes.Num(); i += sizeof(TCHAR))
+			{
+				TCHAR* Char = static_cast<TCHAR*>(static_cast<void*>(&Bytes[i]));
+				Out += *Char;
+			}
+			OutString = Out;
+			WriteStream->Close();
+			delete WriteStream;
+			return true;
+		}
+		return false;
+	}
+
+	bool Interpret(FArchive& WriteStream, TScriptInterface<ISimpleTemplateDataProvider> DataProvider)
+	{
+		return DataProvider != nullptr ? Interpret(WriteStream, DataProvider->GetData()) : false;
+	}
+
+	bool Interpret(FString& OutString, TScriptInterface<ISimpleTemplateDataProvider> DataProvider)
+	{
+		return DataProvider != nullptr ? Interpret(OutString, DataProvider->GetData()) : false;
+	}
+
+protected:
+	TTemplateInterpreter(FTokenArray& InTokenTree)
+		: TokenTree(InTokenTree)
+	{
+	}
+
+protected:
+	FTokenArray const TokenTree;
+};
+
+template <class CharType = TCHAR>
+class SIMPLETEMPLATE_API TTemplateCompilerFactory
+{
+public:
+
+    // Add string streams plus BP objects, then we can create a BP lib to parse stuff
+	static TSharedRef<TTemplateTokenizer<CharType>> Create(const FString& JsonString)
+	{
+		return FStringTemplateParser::Create(JsonString);
+	}
+
+    static TSharedRef<TTemplateTokenizer<CharType>> Create(FArchive* const Stream)
+    {
+        return TTemplateTokenizer<CharType>::Create(Stream);
+    }
+};

--- a/Source/SimpleTemplate/Public/Interfaces/SimpleTemplateDataProvider.h
+++ b/Source/SimpleTemplate/Public/Interfaces/SimpleTemplateDataProvider.h
@@ -1,0 +1,25 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/ObjectMacros.h"
+#include "UObject/Interface.h"
+#include "Dom/JsonObject.h"
+#include "SimpleTemplateDataProvider.generated.h"
+
+UINTERFACE(BlueprintType)
+class SIMPLETEMPLATE_API USimpleTemplateDataProvider : public UInterface
+{
+    GENERATED_UINTERFACE_BODY()
+};
+
+/**
+* Derive from this class
+*/
+class SIMPLETEMPLATE_API ISimpleTemplateDataProvider
+{
+    GENERATED_IINTERFACE_BODY()
+
+    virtual TSharedPtr<FJsonObject> GetData() const = 0;
+};

--- a/Source/SimpleTemplate/Public/Kismet/SimpleTemplateLibrary.h
+++ b/Source/SimpleTemplate/Public/Kismet/SimpleTemplateLibrary.h
@@ -1,0 +1,25 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "Compiler/SimpleTemplateCompiler.h"
+#include "SimpleTemplate.h"
+#include "SimpleTemplateData.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "SimpleTemplateLibrary.generated.h"
+
+UCLASS()
+class SIMPLETEMPLATE_API USimpleTemplateLibrary : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+
+	/** Interpret a template */
+	UFUNCTION(BlueprintCallable, Category = "Simple Template Engine")
+	static FString Interpret(USimpleTemplate* SimpleTemplate, TScriptInterface<ISimpleTemplateDataProvider> DataProvider);
+
+	/** Create a simple data provider */
+	UFUNCTION(BlueprintCallable, Category = "Simple Template Engine")
+	static USimpleTemplateData* NewDataProvider(const FString& Data);
+};

--- a/Source/SimpleTemplate/Public/SimpleTemplate.h
+++ b/Source/SimpleTemplate/Public/SimpleTemplate.h
@@ -1,0 +1,96 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "Internationalization/Text.h"
+#include "UObject/Object.h"
+#include "UObject/ObjectMacros.h"
+
+#include "SimpleTemplateData.h"
+#include "Compiler/SimpleTemplateCompiler.h"
+
+#include "Interfaces/SimpleTemplateDataProvider.h"
+
+#include "SimpleTemplate.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSTE, Verbose, All);
+
+/**
+* Enumerates states a template can be in.
+*/
+UENUM()
+enum class ETemplateStatus : uint8
+{
+	/** Template is in an unknown state. */
+	TS_Unknown,
+	/** Template has been modified but not recompiled. */
+	TS_Dirty,
+	/** Template tried but failed to be compiled. */
+	TS_Error,
+	/** Template has been compiled since it was last modified. */
+	TS_UpToDate,
+	/** Template is in the process of being created for the first time. */
+	TS_BeingCreated
+};
+
+/**
+ * Asset used to implement complex template replace logic.
+ */
+UCLASS(BlueprintType, hidecategories=(Object))
+class SIMPLETEMPLATE_API USimpleTemplate
+	: public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+#if WITH_EDITOR
+	/** Holds the stored text. */
+	UPROPERTY(BlueprintReadOnly, EditAnywhere, Category="Simple Template")
+	FText Template;
+
+	// TemplateError
+	UPROPERTY()
+	TArray<FString> LastErrors;
+
+	// Line and chars used to goto in case of an error
+	UPROPERTY()
+	uint32 LineNumber;
+	UPROPERTY()
+	uint32 CharacterNumber;
+
+	bool Compile();
+
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+
+#endif
+
+	bool IsUpToDate() const
+	{
+		return ETemplateStatus::TS_UpToDate == Status;
+	}
+
+	bool IsPossiblyDirty() const
+	{
+		return (ETemplateStatus::TS_Dirty == Status) || (ETemplateStatus::TS_Unknown == Status);
+	}
+
+	bool IsError() const
+	{
+		return (ETemplateStatus::TS_Error == Status);
+	}
+
+	FString Interpret(TScriptInterface<ISimpleTemplateDataProvider> DataProvider);
+
+	// UObject interface
+	virtual void Serialize(FArchive& Ar) override;
+
+public:
+
+	/** The current status of this template */
+	UPROPERTY()
+	ETemplateStatus Status;
+
+	/** Compiled tokens */
+	FTokenArray Tokens;
+};

--- a/Source/SimpleTemplate/Public/SimpleTemplateData.h
+++ b/Source/SimpleTemplate/Public/SimpleTemplateData.h
@@ -1,0 +1,36 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "Internationalization/Text.h"
+#include "UObject/Object.h"
+#include "UObject/ObjectMacros.h"
+#include "Dom/JsonObject.h"
+#include "Interfaces/SimpleTemplateDataProvider.h"
+
+#include "SimpleTemplateData.generated.h"
+
+/**
+ *Object used to provide a SimpleTemplate with data
+ */
+UCLASS(BlueprintType, hidecategories=(Object))
+class SIMPLETEMPLATE_API USimpleTemplateData : public UObject, public ISimpleTemplateDataProvider
+{
+    GENERATED_BODY()
+
+public:
+	USimpleTemplateData();
+
+    /** The template data */
+    UPROPERTY(EditAnywhere, Category = "Data")
+    FString Json;
+
+	UFUNCTION(BlueprintCallable, Category = "Data")
+	bool SetData(const FString& Data);
+
+	virtual TSharedPtr<FJsonObject> GetData() const override;
+
+private:
+	FString JsonString;
+	TSharedPtr<FJsonObject> JsonPtr;
+};

--- a/Source/SimpleTemplate/SimpleTemplate.Build.cs
+++ b/Source/SimpleTemplate/SimpleTemplate.Build.cs
@@ -1,0 +1,25 @@
+// Copyright Playspace S.L. 2017
+
+namespace UnrealBuildTool.Rules
+{
+	public class SimpleTemplate : ModuleRules
+	{
+		public SimpleTemplate(ReadOnlyTargetRules Target) : base(Target)
+		{
+			PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+			PublicDependencyModuleNames.AddRange(
+				new string[] {
+					"Core",
+					"CoreUObject",
+                    "Engine",
+                    "Json"
+				});
+
+			PrivateIncludePaths.AddRange(
+				new string[] {
+					"Runtime/SimpleTemplate/Private",
+				});
+		}
+	}
+}

--- a/Source/SimpleTemplateEditor/Private/AssetTools/SimpleTemplateActions.cpp
+++ b/Source/SimpleTemplateEditor/Private/AssetTools/SimpleTemplateActions.cpp
@@ -1,0 +1,155 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplateActions.h"
+
+#include "Framework/MultiBox/MultiBoxBuilder.h"
+#include "Styling/SlateStyle.h"
+
+#include "Framework/Application/SlateApplication.h"
+#include "DesktopPlatformModule.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+
+#include "SimpleTemplateEditorToolkit.h"
+
+
+#define LOCTEXT_NAMESPACE "AssetTypeActions"
+
+
+/* FSimpleTemplateActions constructors
+ *****************************************************************************/
+
+FSimpleTemplateActions::FSimpleTemplateActions(const TSharedRef<ISlateStyle>& InStyle)
+	: Style(InStyle)
+{ }
+
+
+/* FAssetTypeActions_Base overrides
+ *****************************************************************************/
+
+bool FSimpleTemplateActions::CanFilter()
+{
+	return true;
+}
+
+
+void FSimpleTemplateActions::GetActions(const TArray<UObject*>& InObjects, FMenuBuilder& MenuBuilder)
+{
+	FAssetTypeActions_Base::GetActions(InObjects, MenuBuilder);
+
+	auto SimpleTemplates = GetTypedWeakObjectPtrs<USimpleTemplate>(InObjects);
+
+
+	MenuBuilder.AddMenuEntry(
+		LOCTEXT("SimpleTemplate_Compile", "Compile"),
+		LOCTEXT("SimpleTemplate_CompileToolTip", "Compile selected SimpleTemplate asset(s)."),
+		FSlateIcon(),
+		FUIAction(FExecuteAction::CreateSP(this, &FSimpleTemplateActions::CompileSelected, SimpleTemplates), FCanExecuteAction()));
+
+	MenuBuilder.AddMenuEntry(
+		LOCTEXT("SimpleTemplate_Export", "Export"),
+		LOCTEXT("SimpleTemplate_ExportToolTip", "Export selected SimpleTemplate asset(s)."),
+		FSlateIcon(),
+		FUIAction(FExecuteAction::CreateSP(this, &FSimpleTemplateActions::ExportTemplates, SimpleTemplates), FCanExecuteAction()));
+}
+
+void FSimpleTemplateActions::CompileSelected(TArray<TWeakObjectPtr<USimpleTemplate>> SimpleTemplates)
+{
+	for (auto& SimpleTemplate : SimpleTemplates)
+	{
+		if (SimpleTemplate.IsValid() && !SimpleTemplate->Template.IsEmpty())
+		{
+			SimpleTemplate->Compile();
+			SimpleTemplate->PostEditChange();
+			SimpleTemplate->MarkPackageDirty();
+		}
+	}
+}
+
+void FSimpleTemplateActions::ExportTemplates(TArray<TWeakObjectPtr<USimpleTemplate>> SimpleTemplates)
+{
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	if (DesktopPlatform != nullptr)
+	{
+		FString OutputDirectory = FPaths::GameDir();
+		FString FolderPath;
+		const bool bFolderSelected = DesktopPlatform->OpenDirectoryDialog(
+			FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+			LOCTEXT("FolderDialogTitle", "Choose a directory to export the templates").ToString(),
+			OutputDirectory,
+			FolderPath
+		);
+
+		if (bFolderSelected)
+		{
+			if (!FolderPath.EndsWith(TEXT("/")))
+			{
+				FolderPath += TEXT("/");
+			}
+
+			OutputDirectory = FolderPath;
+
+			for (auto& SimpleTemplate: SimpleTemplates)
+			{
+				if (SimpleTemplate.IsValid())
+				{
+					TArray<FStringFormatArg> Args;
+					Args.Add(SimpleTemplate->GetName());
+					FString FileName = FString::Format(TEXT("{0}.stf"), Args);
+					FFileHelper::SaveStringToFile(SimpleTemplate->Template.ToString(), *(OutputDirectory / FileName), FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+				}
+			}
+		}
+	}
+}
+
+uint32 FSimpleTemplateActions::GetCategories()
+{
+	return EAssetTypeCategories::Misc;
+}
+
+
+FText FSimpleTemplateActions::GetName() const
+{
+	return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_SimpleTemplate", "Simple Template");
+}
+
+
+UClass* FSimpleTemplateActions::GetSupportedClass() const
+{
+	return USimpleTemplate::StaticClass();
+}
+
+
+FColor FSimpleTemplateActions::GetTypeColor() const
+{
+	return FColor::White;
+}
+
+
+bool FSimpleTemplateActions::HasActions(const TArray<UObject*>& InObjects) const
+{
+	return true;
+}
+
+
+void FSimpleTemplateActions::OpenAssetEditor(const TArray<UObject*>& InObjects, TSharedPtr<IToolkitHost> EditWithinLevelEditor)
+{
+	EToolkitMode::Type Mode = EditWithinLevelEditor.IsValid()
+		? EToolkitMode::WorldCentric
+		: EToolkitMode::Standalone;
+
+	for (auto ObjIt = InObjects.CreateConstIterator(); ObjIt; ++ObjIt)
+	{
+		auto SimpleTemplate = Cast<USimpleTemplate>(*ObjIt);
+
+		if (SimpleTemplate != nullptr)
+		{
+			TSharedRef<FSimpleTemplateEditorToolkit> EditorToolkit = MakeShareable(new FSimpleTemplateEditorToolkit(Style));
+			EditorToolkit->Initialize(SimpleTemplate, Mode, EditWithinLevelEditor);
+		}
+	}
+}
+
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/SimpleTemplateEditor/Private/AssetTools/SimpleTemplateActions.h
+++ b/Source/SimpleTemplateEditor/Private/AssetTools/SimpleTemplateActions.h
@@ -1,0 +1,50 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "AssetTypeActions_Base.h"
+#include "Templates/SharedPointer.h"
+#include "SimpleTemplate.h"
+
+class ISlateStyle;
+
+
+/**
+ * Implements an action for USimpleTemplate assets.
+ */
+class FSimpleTemplateActions
+	: public FAssetTypeActions_Base
+{
+public:
+
+	/**
+	 * Creates and initializes a new instance.
+	 *
+	 * @param InStyle The style set to use for asset editor toolkits.
+	 */
+	FSimpleTemplateActions(const TSharedRef<ISlateStyle>& InStyle);
+
+public:
+
+	//~ FAssetTypeActions_Base overrides
+
+	virtual bool CanFilter() override;
+	virtual void GetActions(const TArray<UObject*>& InObjects, FMenuBuilder& MenuBuilder) override;
+	virtual uint32 GetCategories() override;
+	virtual FText GetName() const override;
+	virtual UClass* GetSupportedClass() const override;
+	virtual FColor GetTypeColor() const override;
+	virtual bool HasActions(const TArray<UObject*>& InObjects) const override;
+	virtual void OpenAssetEditor(const TArray<UObject*>& InObjects, TSharedPtr<IToolkitHost> EditWithinLevelEditor = TSharedPtr<IToolkitHost>()) override;
+
+private:
+
+	/** Pointer to the style set to use for toolkits. */
+	TSharedRef<ISlateStyle> Style;
+
+	/** Compile a selection of assets */
+	void CompileSelected(TArray<TWeakObjectPtr<USimpleTemplate>> SimpleTemplates);
+
+	/** Export a selection */
+	void ExportTemplates(TArray<TWeakObjectPtr<USimpleTemplate>> SimpleTemplates);
+};

--- a/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactory.cpp
+++ b/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactory.cpp
@@ -1,0 +1,37 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplateFactory.h"
+
+#include "Containers/UnrealString.h"
+#include "SimpleTemplate.h"
+#include "Misc/FileHelper.h"
+
+
+/* USimpleTemplateFactory structors
+ *****************************************************************************/
+
+USimpleTemplateFactory::USimpleTemplateFactory( const FObjectInitializer& ObjectInitializer )
+	: Super(ObjectInitializer)
+{
+	Formats.Add(FString(TEXT("stf;")) + NSLOCTEXT("USimpleTemplateFactory", "FormatTxt", "Simple Template File").ToString());
+	SupportedClass = USimpleTemplate::StaticClass();
+	bCreateNew = false;
+	bEditorImport = true;
+}
+
+UObject* USimpleTemplateFactory::FactoryCreateFile(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, const FString& Filename, const TCHAR* Parms, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	USimpleTemplate* SimpleTemplate = nullptr;
+	FString TextString;
+
+	if (FFileHelper::LoadFileToString(TextString, *Filename))
+	{
+		SimpleTemplate = NewObject<USimpleTemplate>(InParent, InClass, InName, Flags);
+		SimpleTemplate->Template = FText::FromString(TextString);
+		SimpleTemplate->Status = ETemplateStatus::TS_BeingCreated;
+	}
+
+	bOutOperationCanceled = false;
+
+	return SimpleTemplate;
+}

--- a/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactory.h
+++ b/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactory.h
@@ -1,0 +1,26 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "Factories/Factory.h"
+#include "UObject/ObjectMacros.h"
+
+#include "SimpleTemplateFactory.generated.h"
+
+
+/**
+ * Implements a factory for USimpleTemplate objects.
+ */
+UCLASS(hidecategories=Object)
+class USimpleTemplateFactory
+	: public UFactory
+{
+	GENERATED_UCLASS_BODY()
+
+public:
+
+	//~ UFactory Interface
+
+//	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn) override;
+	virtual UObject* FactoryCreateFile(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, const FString& Filename, const TCHAR* Parms, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};

--- a/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactoryNew.cpp
+++ b/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactoryNew.cpp
@@ -1,0 +1,34 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplateFactoryNew.h"
+
+#include "SimpleTemplate.h"
+
+
+/* USimpleTemplateFactoryNew structors
+ *****************************************************************************/
+
+USimpleTemplateFactoryNew::USimpleTemplateFactoryNew(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	SupportedClass = USimpleTemplate::StaticClass();
+	bCreateNew = true;
+	bEditAfterNew = true;
+}
+
+
+/* UFactory overrides
+ *****************************************************************************/
+
+UObject* USimpleTemplateFactoryNew::FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
+{
+	USimpleTemplate* SimpleTemplate = NewObject<USimpleTemplate>(InParent, InClass, InName, Flags);
+	SimpleTemplate->Status = ETemplateStatus::TS_BeingCreated;
+	return SimpleTemplate;
+}
+
+
+bool USimpleTemplateFactoryNew::ShouldShowInNewMenu() const
+{
+	return true;
+}

--- a/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactoryNew.h
+++ b/Source/SimpleTemplateEditor/Private/Factories/SimpleTemplateFactoryNew.h
@@ -1,0 +1,26 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "Factories/Factory.h"
+#include "UObject/ObjectMacros.h"
+
+#include "SimpleTemplateFactoryNew.generated.h"
+
+
+/**
+ * Implements a factory for USimpleTemplate objects.
+ */
+UCLASS(hidecategories=Object)
+class USimpleTemplateFactoryNew
+	: public UFactory
+{
+	GENERATED_UCLASS_BODY()
+
+public:
+
+	//~ UFactory Interface
+
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+};

--- a/Source/SimpleTemplateEditor/Private/Shared/SimpleTemplateEditorSettings.cpp
+++ b/Source/SimpleTemplateEditor/Private/Shared/SimpleTemplateEditorSettings.cpp
@@ -1,0 +1,13 @@
+// Copyright 1998-2015 Epic Games, Inc. All Rights Reserved.
+
+#include "SimpleTemplateEditorSettings.h"
+
+#include "Misc/Paths.h"
+
+
+USimpleTemplateEditorSettings::USimpleTemplateEditorSettings()
+	: BackgroundColor(FLinearColor::White)
+	, ForegroundColor(FLinearColor::Black)
+	, Font(FSlateFontInfo(FPaths::EngineContentDir() / TEXT("Slate/Fonts/DroidSansMono.ttf"), 10))
+	, Margin(4.0f)
+{ }

--- a/Source/SimpleTemplateEditor/Private/Shared/SimpleTemplateEditorSettings.h
+++ b/Source/SimpleTemplateEditor/Private/Shared/SimpleTemplateEditorSettings.h
@@ -1,0 +1,40 @@
+// Copyright 1998-2015 Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Fonts/SlateFontInfo.h"
+#include "Styling/SlateColor.h"
+#include "UObject/ObjectMacros.h"
+
+#include "SimpleTemplateEditorSettings.generated.h"
+
+
+UCLASS(config=Editor)
+class SIMPLETEMPLATEEDITOR_API USimpleTemplateEditorSettings
+	: public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+	/** Color of the SimpleTemplate editor's background. */
+	UPROPERTY(config, EditAnywhere, Category=Appearance)
+	FSlateColor BackgroundColor;
+
+	/** Color of the SimpleTemplate editor's text. */
+	UPROPERTY(config, EditAnywhere, Category=Appearance)
+	FSlateColor ForegroundColor;
+
+	/** The font to use in the SimpleTemplate editor window. */
+	UPROPERTY(config, EditAnywhere, Category=Appearance)
+	FSlateFontInfo Font;
+
+	/** The margin around the SimpleTemplate editor window (in pixels). */
+	UPROPERTY(config, EditAnywhere, Category=Appearance)
+	float Margin;
+
+public:
+
+	/** Default constructor. */
+	USimpleTemplateEditorSettings();
+};

--- a/Source/SimpleTemplateEditor/Private/SimpleTemplateEditorModule.cpp
+++ b/Source/SimpleTemplateEditor/Private/SimpleTemplateEditorModule.cpp
@@ -1,0 +1,173 @@
+// Copyright Playspace S.L. 2017
+
+#include "Containers/Array.h"
+#include "ISettingsModule.h"
+#include "ISettingsSection.h"
+#include "Modules/ModuleInterface.h"
+#include "Modules/ModuleManager.h"
+#include "Templates/SharedPointer.h"
+#include "Toolkits/AssetEditorToolkit.h"
+
+#include "AssetTools/SimpleTemplateActions.h"
+#include "Styles/SimpleTemplateEditorStyle.h"
+#include "SimpleTemplateEditorSettings.h"
+#include "SimpleTemplateEditorCommands.h"
+
+
+#define LOCTEXT_NAMESPACE "FSimpleTemplateEditorModule"
+
+
+/**
+ * Implements the SimpleTemplateEditor module.
+ */
+class FSimpleTemplateEditorModule
+	: public IHasMenuExtensibility
+	, public IHasToolBarExtensibility
+	, public IModuleInterface
+{
+public:
+
+	//~ IHasMenuExtensibility interface
+
+	virtual TSharedPtr<FExtensibilityManager> GetMenuExtensibilityManager() override
+	{
+		return MenuExtensibilityManager;
+	}
+
+public:
+
+	//~ IHasToolBarExtensibility interface
+
+	virtual TSharedPtr<FExtensibilityManager> GetToolBarExtensibilityManager() override
+	{
+		return ToolBarExtensibilityManager;
+	}
+
+public:
+
+	//~ IModuleInterface interface
+
+	virtual void StartupModule() override
+	{
+		FSimpleTemplateEditorCommands::Register();
+
+		// Register slate style overrides
+		FSimpleTemplateStyle::Initialize();
+
+		RegisterAssetTools();
+		RegisterMenuExtensions();
+		RegisterSettings();
+	}
+
+	virtual void ShutdownModule() override
+	{
+		UnregisterAssetTools();
+		UnregisterMenuExtensions();
+		UnregisterSettings();
+
+		// Unregister slate style overrides
+		FSimpleTemplateStyle::Shutdown();
+	}
+
+	virtual bool SupportsDynamicReloading() override
+	{
+		return true;
+	}
+
+protected:
+
+	/** Registers asset tool actions. */
+	void RegisterAssetTools()
+	{
+		IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+
+		RegisterAssetTypeAction(AssetTools, MakeShareable(new FSimpleTemplateActions(FSimpleTemplateStyle::Get().ToSharedRef())));
+	}
+
+	/**
+	 * Registers a single asset type action.
+	 *
+	 * @param AssetTools The asset tools object to register with.
+	 * @param Action The asset type action to register.
+	 */
+	void RegisterAssetTypeAction(IAssetTools& AssetTools, TSharedRef<IAssetTypeActions> Action)
+	{
+		AssetTools.RegisterAssetTypeActions(Action);
+		RegisteredAssetTypeActions.Add(Action);
+	}
+
+	/** Register the Simple Template editor settings. */
+	void RegisterSettings()
+	{
+		ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
+
+		if (SettingsModule != nullptr)
+		{
+			ISettingsSectionPtr SettingsSection = SettingsModule->RegisterSettings("Editor", "Plugins", "SimpleTemplate",
+				LOCTEXT("SimpleTemplateSettingsName", "Simple Template"),
+				LOCTEXT("SimpleTemplateSettingsDescription", "Configure the Simple Template plug-in."),
+				GetMutableDefault<USimpleTemplateEditorSettings>()
+			);
+		}
+	}
+
+	/** Unregisters asset tool actions. */
+	void UnregisterAssetTools()
+	{
+		FAssetToolsModule* AssetToolsModule = FModuleManager::GetModulePtr<FAssetToolsModule>("AssetTools");
+
+		if (AssetToolsModule != nullptr)
+		{
+			IAssetTools& AssetTools = AssetToolsModule->Get();
+
+			for (auto Action : RegisteredAssetTypeActions)
+			{
+				AssetTools.UnregisterAssetTypeActions(Action);
+			}
+		}
+	}
+
+	/** Unregister the Simple Template editor settings. */
+	void UnregisterSettings()
+	{
+		ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
+
+		if (SettingsModule != nullptr)
+		{
+			SettingsModule->UnregisterSettings("Editor", "Plugins", "SimpleTemplate");
+		}
+	}
+
+protected:
+
+	/** Registers main menu and tool bar menu extensions. */
+	void RegisterMenuExtensions()
+	{
+		MenuExtensibilityManager = MakeShareable(new FExtensibilityManager);
+		ToolBarExtensibilityManager = MakeShareable(new FExtensibilityManager);
+	}
+
+	/** Unregisters main menu and tool bar menu extensions. */
+	void UnregisterMenuExtensions()
+	{
+		MenuExtensibilityManager.Reset();
+		ToolBarExtensibilityManager.Reset();
+	}
+
+private:
+
+	/** Holds the menu extensibility manager. */
+	TSharedPtr<FExtensibilityManager> MenuExtensibilityManager;
+
+	/** The collection of registered asset type actions. */
+	TArray<TSharedRef<IAssetTypeActions>> RegisteredAssetTypeActions;
+
+	/** Holds the tool bar extensibility manager. */
+	TSharedPtr<FExtensibilityManager> ToolBarExtensibilityManager;
+};
+
+
+IMPLEMENT_MODULE(FSimpleTemplateEditorModule, SimpleTemplateEditor);
+
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/SimpleTemplateEditor/Private/Styles/SimpleTemplateEditorStyle.cpp
+++ b/Source/SimpleTemplateEditor/Private/Styles/SimpleTemplateEditorStyle.cpp
@@ -1,0 +1,89 @@
+// Copyright Playspace S.L. 2017
+
+#include "Styles/SimpleTemplateEditorStyle.h"
+#include "Styling/SlateStyleRegistry.h"
+#include "Styling/SlateTypes.h"
+#include "EditorStyleSet.h"
+#include "Interfaces/IPluginManager.h"
+#include "SlateOptMacros.h"
+
+
+#define IMAGE_PLUGIN_BRUSH( RelativePath, ... ) FSlateImageBrush( FSimpleTemplateStyle::InContent( RelativePath, ".png" ), __VA_ARGS__ )
+#define IMAGE_BRUSH(RelativePath, ...) FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")), __VA_ARGS__)
+#define BOX_BRUSH(RelativePath, ...) FSlateBoxBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")), __VA_ARGS__)
+#define TTF_FONT(RelativePath, ...) FSlateFontInfo(StyleSet->RootToContentDir(RelativePath, TEXT(".ttf")), __VA_ARGS__)
+#define TTF_CORE_FONT(RelativePath, ...) FSlateFontInfo(StyleSet->RootToCoreContentDir(RelativePath, TEXT(".ttf") ), __VA_ARGS__)
+
+FString FSimpleTemplateStyle::InContent(const FString& RelativePath, const ANSICHAR* Extension)
+{
+	static FString ContentDir = IPluginManager::Get().FindPlugin(TEXT("SimpleTemplate"))->GetContentDir();
+	return (ContentDir / RelativePath) + Extension;
+}
+
+TSharedPtr< FSlateStyleSet > FSimpleTemplateStyle::StyleSet = nullptr;
+TSharedPtr< class ISlateStyle > FSimpleTemplateStyle::Get() { return StyleSet; }
+
+FName FSimpleTemplateStyle::GetStyleSetName()
+{
+	static FName SimpleTemplateStyleName(TEXT("SimpleTemplateStyle"));
+	return SimpleTemplateStyleName;
+}
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+void FSimpleTemplateStyle::Initialize()
+{
+	// Const icon sizes
+	const FVector2D Icon16x16(16.0f, 16.0f);	
+	const FVector2D Icon40x40(40.0f, 40.0f);
+	const FVector2D Icon64x64(64.0f, 64.0f);
+
+	// Only register once
+	if (StyleSet.IsValid())
+	{
+		return;
+	}
+
+	StyleSet = MakeShareable(new FSlateStyleSet(GetStyleSetName()));
+	StyleSet->SetContentRoot(FPaths::EngineContentDir() / TEXT("Editor/Slate"));
+	StyleSet->SetCoreContentRoot(FPaths::EngineContentDir() / TEXT("Slate"));
+
+	// Class icons
+	{
+		StyleSet->Set("ClassIcon.SimpleTemplate", new IMAGE_PLUGIN_BRUSH("Icons/SimpleTemplate_16x", Icon16x16));
+		StyleSet->Set("ClassThumbnail.SimpleTemplate", new IMAGE_PLUGIN_BRUSH("Icons/SimpleTemplate_64x", Icon64x64));
+	}
+
+	// Template editor
+	{
+		StyleSet->Set("SimpleTemplateEditor.Compile", new IMAGE_PLUGIN_BRUSH("Icons/icon_compile_40x", Icon40x40));
+		StyleSet->Set("SimpleTemplateEditor.Compile.Dirty", new IMAGE_PLUGIN_BRUSH("Icons/icon_compile_dirty_40x", Icon40x40));
+		StyleSet->Set("SimpleTemplateEditor.Compile.Error", new IMAGE_PLUGIN_BRUSH("Icons/icon_compile_error_40x", Icon40x40));
+		StyleSet->Set("SimpleTemplateEditor.Export", new IMAGE_PLUGIN_BRUSH("Icons/icon_export_40x", Icon40x40));
+		StyleSet->Set("SimpleTemplateEditor.Import", new IMAGE_PLUGIN_BRUSH("Icons/icon_import_40x", Icon40x40));
+	}
+
+	// Text Editor
+	{
+		StyleSet->Set("TextEditor.Border", new BOX_BRUSH("UI/TextEditorBorder", FMargin(4.0f / 16.0f), FLinearColor(0.02f, 0.02f, 0.02f, 1)));
+	}
+
+	FSlateStyleRegistry::RegisterSlateStyle(*StyleSet.Get());
+};
+
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+
+#undef IMAGE_PLUGIN_BRUSH
+#undef IMAGE_BRUSH
+#undef BOX_BRUSH
+#undef TTF_FONT
+#undef TTF_CORE_FONT
+
+void FSimpleTemplateStyle::Shutdown()
+{
+	if (StyleSet.IsValid())
+	{
+		FSlateStyleRegistry::UnRegisterSlateStyle(*StyleSet.Get());
+	}
+}

--- a/Source/SimpleTemplateEditor/Private/Styles/SimpleTemplateEditorStyle.h
+++ b/Source/SimpleTemplateEditor/Private/Styles/SimpleTemplateEditorStyle.h
@@ -1,0 +1,24 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Styling/ISlateStyle.h"
+#include "Styling/SlateStyle.h"
+
+class FSimpleTemplateStyle
+{
+public:
+	static void Initialize();
+
+	static void Shutdown();
+
+	static TSharedPtr< class ISlateStyle > Get();
+
+	static FName GetStyleSetName();
+private:
+	static FString InContent(const FString& RelativePath, const ANSICHAR* Extension);
+
+private:
+	static TSharedPtr< class FSlateStyleSet > StyleSet;
+};

--- a/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorCommands.cpp
+++ b/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorCommands.cpp
@@ -1,0 +1,14 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplateEditorCommands.h"
+
+#define LOCTEXT_NAMESPACE "SimpleTemplateEditorCommands"
+
+void FSimpleTemplateEditorCommands::RegisterCommands()
+{
+	UI_COMMAND(Compile, "Compile", "Compile a template", EUserInterfaceActionType::Button, FInputChord());
+	UI_COMMAND(Import, "Import", "Import a template from a .stf file", EUserInterfaceActionType::Button, FInputChord());
+	UI_COMMAND(Export, "Export", "Export a template to a .stf file.", EUserInterfaceActionType::Button, FInputChord());
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorCommands.h
+++ b/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorCommands.h
@@ -1,0 +1,30 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Framework/Commands/Commands.h"
+#include "SimpleTemplateEditorStyle.h"
+
+class FSimpleTemplateEditorCommands : public TCommands<FSimpleTemplateEditorCommands>
+{
+public:
+	FSimpleTemplateEditorCommands()
+		: TCommands<FSimpleTemplateEditorCommands>(
+			TEXT("SimpleTemplateEditor"), // Context name for fast lookup
+			NSLOCTEXT("Contexts", "SimpleTemplateEditor", "SimpleTemplate Editor"), // Localized context name for displaying
+			NAME_None, // Parent
+			FSimpleTemplateStyle::GetStyleSetName()
+			)
+	{
+	}
+
+	// TCommand<> interface
+	virtual void RegisterCommands() override;
+	// End of TCommand<> interface
+
+public:
+	TSharedPtr<FUICommandInfo> Compile;
+	TSharedPtr<FUICommandInfo> Import;
+	TSharedPtr<FUICommandInfo> Export;
+};

--- a/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorToolkit.cpp
+++ b/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorToolkit.cpp
@@ -1,0 +1,444 @@
+// Copyright Playspace S.L. 2017
+
+#include "SimpleTemplateEditorToolkit.h"
+
+#include "Editor.h"
+#include "EditorReimportHandler.h"
+#include "EditorStyleSet.h"
+#include "SimpleTemplate.h"
+#include "UObject/NameTypes.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "Framework/MultiBox/MultiBoxExtender.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
+
+#include "Framework/Application/SlateApplication.h"
+#include "DesktopPlatformModule.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "EditorDirectories.h"
+
+#define LOCTEXT_NAMESPACE "FSimpleTemplateEditorToolkit"
+
+DEFINE_LOG_CATEGORY_STATIC(LogSimpleTemplateEditor, Log, All);
+
+
+/* Local constants
+ *****************************************************************************/
+
+namespace SimpleTemplateEditor
+{
+	static const FName AppIdentifier("SimpleTemplateEditorApp");
+	static const FName TabId("TemplateEditor");
+	static const FName OutputTabId("TemplateCompileOutput");
+}
+
+
+/* FSimpleTemplateEditorToolkit structors
+ *****************************************************************************/
+
+FSimpleTemplateEditorToolkit::FSimpleTemplateEditorToolkit(const TSharedRef<ISlateStyle>& InStyle)
+	: SimpleTemplate(nullptr)
+	, Style(InStyle)
+{ }
+
+
+FSimpleTemplateEditorToolkit::~FSimpleTemplateEditorToolkit()
+{
+	FReimportManager::Instance()->OnPreReimport().RemoveAll(this);
+	FReimportManager::Instance()->OnPostReimport().RemoveAll(this);
+
+	GEditor->UnregisterForUndo(this);
+}
+
+
+/* FSimpleTemplateEditorToolkit interface
+ *****************************************************************************/
+
+void FSimpleTemplateEditorToolkit::Initialize(USimpleTemplate* InSimpleTemplate, const EToolkitMode::Type InMode, const TSharedPtr<class IToolkitHost>& InToolkitHost)
+{
+	BindCommands();
+
+	SimpleTemplate = InSimpleTemplate;
+
+	// Support undo/redo
+	SimpleTemplate->SetFlags(RF_Transactional);
+	GEditor->RegisterForUndo(this);
+
+	// create tab layout
+	const TSharedRef<FTabManager::FLayout> Layout = FTabManager::NewLayout("Standalone_SimpleTemplateEditor")
+		->AddArea
+		(
+			FTabManager::NewPrimaryArea()
+				->SetOrientation(Orient_Horizontal)
+				->Split
+				(
+					FTabManager::NewSplitter()
+						->SetOrientation(Orient_Vertical)
+						->SetSizeCoefficient(0.66f)
+
+						// Toolbar
+						->Split
+						(
+							FTabManager::NewStack()
+								->AddTab(GetToolbarTabId(), ETabState::OpenedTab)
+								->SetHideTabWell(true)
+								->SetSizeCoefficient(0.1f)
+								
+						)
+
+						// Compile error view
+						->Split
+						(
+							FTabManager::NewStack()
+							->AddTab(SimpleTemplateEditor::OutputTabId, ETabState::ClosedTab)
+							->SetHideTabWell(true)
+							->SetSizeCoefficient(0.1f)
+						)
+						
+						// Template editor
+						->Split
+						(
+							FTabManager::NewStack()
+								->AddTab(SimpleTemplateEditor::TabId, ETabState::OpenedTab)
+								->SetHideTabWell(false)
+								->SetSizeCoefficient(0.8f)
+						)
+				)
+		);
+
+	FAssetEditorToolkit::InitAssetEditor(
+		InMode,
+		InToolkitHost,
+		SimpleTemplateEditor::AppIdentifier,
+		Layout,
+		true /*bCreateDefaultStandaloneMenu*/,
+		true /*bCreateDefaultToolbar*/,
+		InSimpleTemplate
+	);
+
+	ExtendMenu();
+	ExtendToolbar();
+	RegenerateMenusAndToolbars();
+}
+
+
+/* FAssetEditorToolkit interface
+ *****************************************************************************/
+
+FString FSimpleTemplateEditorToolkit::GetDocumentationLink() const
+{
+	return FString(TEXT("https://github.com/PlayspaceDev/SimpleTemplateEngine"));
+}
+
+
+void FSimpleTemplateEditorToolkit::RegisterTabSpawners(const TSharedRef<FTabManager>& InTabManager)
+{
+	WorkspaceMenuCategory = InTabManager->AddLocalWorkspaceMenuCategory(LOCTEXT("WorkspaceMenu_SimpleTemplateEditor", "Simple Template Editor"));
+	auto WorkspaceMenuCategoryRef = WorkspaceMenuCategory.ToSharedRef();
+
+	FAssetEditorToolkit::RegisterTabSpawners(InTabManager);
+
+	InTabManager->RegisterTabSpawner(SimpleTemplateEditor::TabId, FOnSpawnTab::CreateSP(this, &FSimpleTemplateEditorToolkit::HandleTabManagerSpawnTab, SimpleTemplateEditor::TabId))
+		.SetDisplayName(LOCTEXT("TemplateEditorTabName", "Template Editor"))
+		.SetGroup(WorkspaceMenuCategoryRef)
+		.SetIcon(FSlateIcon(FEditorStyle::GetStyleSetName(), "LevelEditor.Tabs.Viewports"));
+
+	InTabManager->RegisterTabSpawner(SimpleTemplateEditor::OutputTabId, FOnSpawnTab::CreateSP(this, &FSimpleTemplateEditorToolkit::HandleTabManagerSpawnTab, SimpleTemplateEditor::OutputTabId))
+		.SetDisplayName(LOCTEXT("CompileOutputTabName", "Compile Output"))
+		.SetGroup(WorkspaceMenuCategoryRef)
+		.SetIcon(FSlateIcon(FEditorStyle::GetStyleSetName(), "LevelEditor.Tabs.Viewports"));
+}
+
+
+void FSimpleTemplateEditorToolkit::UnregisterTabSpawners(const TSharedRef<FTabManager>& InTabManager)
+{
+	FAssetEditorToolkit::UnregisterTabSpawners(InTabManager);
+
+	InTabManager->UnregisterTabSpawner(SimpleTemplateEditor::TabId);
+}
+
+
+/* IToolkit interface
+ *****************************************************************************/
+
+FText FSimpleTemplateEditorToolkit::GetBaseToolkitName() const
+{
+	return LOCTEXT("AppLabel", "Simple Template Editor");
+}
+
+
+FName FSimpleTemplateEditorToolkit::GetToolkitFName() const
+{
+	return FName("SimpleTemplateEditor");
+}
+
+FText FSimpleTemplateEditorToolkit::GetToolkitName() const
+{
+	if (SimpleTemplate != nullptr)
+	{
+		const bool bDirtyState = SimpleTemplate->GetOutermost()->IsDirty();
+
+		FFormatNamedArguments Args;
+		Args.Add(TEXT("DirtyState"), bDirtyState ? FText::FromString(TEXT("*")) : FText::GetEmpty());
+
+		Args.Add(TEXT("TemplateName"), FText::FromString(SimpleTemplate->GetName()));
+		return FText::Format(LOCTEXT("EditorTitle", "{TemplateName}{DirtyState}"), Args);
+	}
+	return FText::GetEmpty();
+}
+
+
+FLinearColor FSimpleTemplateEditorToolkit::GetWorldCentricTabColorScale() const
+{
+	return FLinearColor(0.3f, 0.2f, 0.5f, 0.5f);
+}
+
+
+FString FSimpleTemplateEditorToolkit::GetWorldCentricTabPrefix() const
+{
+	return LOCTEXT("WorldCentricTabPrefix", "SimpleTemplate ").ToString();
+}
+
+
+/* FGCObject interface
+ *****************************************************************************/
+
+void FSimpleTemplateEditorToolkit::AddReferencedObjects(FReferenceCollector& Collector)
+{
+	Collector.AddReferencedObject(SimpleTemplate);
+}
+
+
+/* FEditorUndoClient interface
+*****************************************************************************/
+
+void FSimpleTemplateEditorToolkit::PostUndo(bool bSuccess)
+{ }
+
+
+void FSimpleTemplateEditorToolkit::PostRedo(bool bSuccess)
+{
+	PostUndo(bSuccess);
+}
+
+
+/* FSimpleTemplateEditorToolkit callbacks
+ *****************************************************************************/
+
+TSharedRef<SDockTab> FSimpleTemplateEditorToolkit::HandleTabManagerSpawnTab(const FSpawnTabArgs& Args, FName TabIdentifier)
+{
+	if (TabIdentifier == SimpleTemplateEditor::TabId)
+	{
+		SAssignNew(TemplateEditor, SSimpleTemplateEditor, SimpleTemplate, Style);
+
+		return SNew(SDockTab)
+			.TabRole(ETabRole::PanelTab)
+			[
+				TemplateEditor.ToSharedRef()
+			];
+	}
+	else if (TabIdentifier == SimpleTemplateEditor::OutputTabId)
+	{
+		FString ErrorText;
+
+		if (SimpleTemplate->LastErrors.Num() > 0)
+		{
+			ErrorText.Append(LOCTEXT("CompileFailed", "Failed to compile template!").ToString());
+			ErrorText.Newline();
+			for (auto& CompileError : SimpleTemplate->LastErrors)
+			{
+				ErrorText.Append(CompileError);
+				ErrorText.Newline();
+			}
+		}
+
+		SAssignNew(TemplateOutput, STextBlock)
+			.Text(ErrorText.Len() > 0 ? FText::FromString(ErrorText) : LOCTEXT("CompileHint", "Compile template"))
+			.ToolTipText(LOCTEXT("OutputTabToolTip", "Compile result, double click to highlight error in editor."))
+			.OnDoubleClicked(this, &FSimpleTemplateEditorToolkit::GoToError);
+
+		return SNew(SDockTab)
+			.TabRole(ETabRole::PanelTab)
+			[
+				TemplateOutput.ToSharedRef()
+			];
+	}
+
+	// Just an empty tab
+	TSharedPtr<SWidget> TabWidget = SNullWidget::NullWidget;
+	return SNew(SDockTab)
+		.TabRole(ETabRole::PanelTab)
+		[
+			TabWidget.ToSharedRef()
+		];
+}
+
+/* Commands and Menu extensions
+*****************************************************************************/
+
+void FSimpleTemplateEditorToolkit::BindCommands()
+{
+	const FSimpleTemplateEditorCommands& Commands = FSimpleTemplateEditorCommands::Get();
+
+	const TSharedRef<FUICommandList>& UICommandList = GetToolkitCommands();
+
+	UICommandList->MapAction(Commands.Compile,
+		FExecuteAction::CreateSP(this, &FSimpleTemplateEditorToolkit::ActionCompile));
+	UICommandList->MapAction(Commands.Export,
+		FExecuteAction::CreateSP(this, &FSimpleTemplateEditorToolkit::ActionExport));
+	UICommandList->MapAction(Commands.Import,
+		FExecuteAction::CreateSP(this, &FSimpleTemplateEditorToolkit::ActionImport));
+}
+
+void FSimpleTemplateEditorToolkit::ExtendMenu()
+{
+}
+
+void FSimpleTemplateEditorToolkit::FillTemplateToolbar(FToolBarBuilder& ToolbarBuilder)
+{
+	ToolbarBuilder.BeginSection("Command");
+	{
+		const FSimpleTemplateEditorCommands& Commands = FSimpleTemplateEditorCommands::Get();
+		ToolbarBuilder.AddToolBarButton(Commands.Compile,
+			NAME_None,
+			TAttribute<FText>(),
+			TAttribute<FText>(this, &FSimpleTemplateEditorToolkit::GetStatusTooltip),
+			TAttribute<FSlateIcon>(this, &FSimpleTemplateEditorToolkit::GetStatusImage),
+			FName(TEXT("Compile")));
+		ToolbarBuilder.AddToolBarButton(Commands.Export);
+		ToolbarBuilder.AddToolBarButton(Commands.Import);
+	}
+	ToolbarBuilder.EndSection();
+}
+
+void FSimpleTemplateEditorToolkit::ExtendToolbar()
+{
+
+	TSharedPtr<FExtender> ToolbarExtender = MakeShareable(new FExtender);
+	ToolbarExtender->AddToolBarExtension(
+		"Asset",
+		EExtensionHook::After,
+		GetToolkitCommands(),
+		FToolBarExtensionDelegate::CreateSP(this, &FSimpleTemplateEditorToolkit::FillTemplateToolbar)
+	);
+
+	AddToolbarExtender(ToolbarExtender);
+}
+
+FSlateIcon FSimpleTemplateEditorToolkit::GetStatusImage() const
+{
+	ETemplateStatus Status = SimpleTemplate->Status;
+	switch (Status)
+	{
+	case ETemplateStatus::TS_Error:
+		return FSlateIcon(FSimpleTemplateStyle::GetStyleSetName(), "SimpleTemplateEditor.Compile.Error");
+	case ETemplateStatus::TS_UpToDate:
+		return FSlateIcon(FSimpleTemplateStyle::GetStyleSetName(), "SimpleTemplateEditor.Compile");
+	}
+	return FSlateIcon(FSimpleTemplateStyle::GetStyleSetName(), "SimpleTemplateEditor.Compile.Dirty");
+}
+
+FText FSimpleTemplateEditorToolkit::GetStatusTooltip() const
+{
+	ETemplateStatus Status = SimpleTemplate->Status;
+	switch (Status)
+	{
+	case ETemplateStatus::TS_Unknown:
+		return LOCTEXT("Recompile_Status", "Unknown status; should recompile");
+	case ETemplateStatus::TS_BeingCreated:
+		return LOCTEXT("Created_Status", "You have to compile the template for the first time");
+	case ETemplateStatus::TS_Dirty:
+		return LOCTEXT("Dirty_Status", "Dirty; needs to be recompiled");
+	case ETemplateStatus::TS_Error:
+		return LOCTEXT("CompileError_Status", "There was an error during compilation, see the log for details");
+	}
+	return LOCTEXT("GoodToGo_Status", "Good to go");
+}
+
+void FSimpleTemplateEditorToolkit::ActionCompile()
+{
+	TemplateOutput->SetText(LOCTEXT("CompileSuccessful", "Template compiled successfully"));
+	if (!SimpleTemplate->Compile())
+	{
+		FString ErrorText;
+		ErrorText.Append(LOCTEXT("CompileFailed", "Failed to compile template!").ToString());
+		ErrorText.Newline();
+		for (auto& CompileError : SimpleTemplate->LastErrors)
+		{
+			ErrorText.Append(CompileError);
+			ErrorText.Newline();
+		}
+		TemplateOutput->SetText(ErrorText);
+	}
+	else
+	{
+		SaveAsset_Execute();
+	}
+}
+
+void FSimpleTemplateEditorToolkit::ActionExport()
+{
+	TArray<FString> SaveFilenames;
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	bool bSaved = false;
+	if (DesktopPlatform != nullptr)
+	{
+		bSaved = DesktopPlatform->SaveFileDialog(
+			FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+			LOCTEXT("ExportDialogTitle", "Export template to file").ToString(),
+			*(FEditorDirectories::Get().GetLastDirectory(ELastDirectory::GENERIC_EXPORT)),
+			TEXT(""),
+			TEXT("Simple Template File|*.stf"),
+			EFileDialogFlags::None,
+			SaveFilenames);
+	}
+
+	if (bSaved)
+	{
+		FString FileName = SaveFilenames[0];
+		FEditorDirectories::Get().SetLastDirectory(ELastDirectory::GENERIC_EXPORT, FPaths::GetPath(FileName)); // Save path as default for next time.
+		FFileHelper::SaveStringToFile(SimpleTemplate->Template.ToString(), *FileName, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+	}
+}
+
+void FSimpleTemplateEditorToolkit::ActionImport()
+{
+	TArray<FString> OpenFilenames;
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	bool bOpened = false;
+	if (DesktopPlatform != nullptr)
+	{
+		const FString DefaultBrowsePath = FString::Printf(TEXT("%slogs/"), *FPaths::GameSavedDir());
+
+		bOpened = DesktopPlatform->OpenFileDialog(
+			FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+			LOCTEXT("OpenProjectBrowseTitle", "Open Project").ToString(),
+			FEditorDirectories::Get().GetLastDirectory(ELastDirectory::GENERIC_OPEN),
+			TEXT(""),
+			TEXT("Simple Template File|*.stf"),
+			EFileDialogFlags::None,
+			OpenFilenames
+		);
+	}
+
+	if (bOpened)
+	{
+		FString FileName = OpenFilenames[0];
+		FString FileContent;
+		if (FFileHelper::LoadFileToString(FileContent, *FileName))
+		{
+			SimpleTemplate->Template = FText::FromString(FileContent);
+			SimpleTemplate->Status = ETemplateStatus::TS_Dirty;
+			SimpleTemplate->PostEditChange();
+			SimpleTemplate->MarkPackageDirty();
+		}		
+	}
+}
+
+FReply FSimpleTemplateEditorToolkit::GoToError()
+{
+	TemplateEditor->GoTo(SimpleTemplate->LineNumber, SimpleTemplate->CharacterNumber);
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorToolkit.h
+++ b/Source/SimpleTemplateEditor/Private/Toolkits/SimpleTemplateEditorToolkit.h
@@ -1,0 +1,117 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "EditorUndoClient.h"
+#include "Templates/SharedPointer.h"
+#include "Toolkits/AssetEditorToolkit.h"
+#include "UObject/GCObject.h"
+#include "SSimpleTemplateEditor.h"
+
+class FSpawnTabArgs;
+class ISlateStyle;
+class IToolkitHost;
+class SDockTab;
+class SSimpleTemplateEditor;
+class USimpleTemplate;
+
+/**
+ * Implements an Editor toolkit for textures.
+ */
+class FSimpleTemplateEditorToolkit
+	: public FAssetEditorToolkit
+	, public FEditorUndoClient
+	, public FGCObject
+{
+public:
+
+	/**
+	 * Creates and initializes a new instance.
+	 *
+	 * @param InStyle The style set to use.
+	 */
+	FSimpleTemplateEditorToolkit(const TSharedRef<ISlateStyle>& InStyle);
+
+	/** Virtual destructor. */
+	virtual ~FSimpleTemplateEditorToolkit();
+
+public:
+
+	/**
+	 * Initializes the editor tool kit.
+	 *
+	 * @param InSimpleTemplate The USimpleTemplate asset to edit.
+	 * @param InMode The mode to create the toolkit in.
+	 * @param InToolkitHost The toolkit host.
+	 */
+	void Initialize(USimpleTemplate* InSimpleTemplate, const EToolkitMode::Type InMode, const TSharedPtr<IToolkitHost>& InToolkitHost);
+
+public:
+
+	//~ FAssetEditorToolkit interface
+
+	virtual FString GetDocumentationLink() const override;
+	virtual void RegisterTabSpawners(const TSharedRef<FTabManager>& InTabManager) override;
+	virtual void UnregisterTabSpawners(const TSharedRef<FTabManager>& InTabManager) override;
+
+public:
+
+	//~ IToolkit interface
+
+	virtual FText GetBaseToolkitName() const override;
+	virtual FName GetToolkitFName() const override;
+	virtual FText GetToolkitName() const override;
+	virtual FLinearColor GetWorldCentricTabColorScale() const override;
+	virtual FString GetWorldCentricTabPrefix() const override;
+
+public:
+
+	//~ FGCObject interface
+
+	virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
+	
+protected:
+
+	//~ FEditorUndoClient interface
+
+	virtual void PostUndo(bool bSuccess) override;
+	virtual void PostRedo(bool bSuccess) override;
+
+protected:
+	void BindCommands();
+	void ExtendMenu();
+	void ExtendToolbar();
+
+private:
+
+	/** Callback for spawning the Properties tab. */
+	TSharedRef<SDockTab> HandleTabManagerSpawnTab(const FSpawnTabArgs& Args, FName TabIdentifier);
+
+	void FillTemplateToolbar(FToolBarBuilder& ToolbarBuilder);
+
+	// Editor actions
+	void ActionCompile();
+	void ActionExport();
+	void ActionImport();
+
+	// Used to navigate to the current error
+	FReply GoToError();
+
+	// Compile action customization
+	FSlateIcon GetStatusImage() const;
+	FText GetStatusTooltip() const;
+
+public:
+
+	// Editor elements
+	TSharedPtr<SSimpleTemplateEditor> TemplateEditor;
+	TSharedPtr<STextBlock> TemplateOutput;
+
+private:
+
+	/** The Simple Template being edited. */
+	USimpleTemplate* SimpleTemplate;
+
+	/** Pointer to the style set to use for toolkits. */
+	TSharedRef<ISlateStyle> Style;
+};

--- a/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditableText.cpp
+++ b/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditableText.cpp
@@ -1,0 +1,44 @@
+// Copyright Playspace S.L. 2017
+
+#include "SSimpleTemplateEditableText.h"
+
+
+void SSimpleTemplateEditableText::Construct( const FArguments& InArgs )
+{
+	SMultiLineEditableText::Construct(
+		SMultiLineEditableText::FArguments()
+		.Text(InArgs._Text)
+		.AutoWrapText(false)
+		.Margin(0)
+		.HScrollBar(InArgs._HScrollBar)
+		.VScrollBar(InArgs._VScrollBar)
+		.OnTextChanged(InArgs._OnTextChanged)
+	);
+}
+
+FReply SSimpleTemplateEditableText::OnKeyChar(const FGeometry& MyGeometry, const FCharacterEvent& InCharacterEvent)
+{
+    FReply Reply = FReply::Unhandled();
+
+    const TCHAR Character = InCharacterEvent.GetCharacter();
+    if(Character == TEXT('\t'))
+    {
+        if (!IsTextReadOnly())
+        {
+            FString String;
+            String.AppendChar(Character);
+            InsertTextAtCursor(String);
+            Reply = FReply::Handled();
+        }
+        else
+        {
+            Reply = FReply::Unhandled();
+        }
+    }
+    else
+    {
+        Reply = SMultiLineEditableText::OnKeyChar( MyGeometry, InCharacterEvent );
+    }
+
+    return Reply;
+}

--- a/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditableText.h
+++ b/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditableText.h
@@ -1,0 +1,34 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Input/Reply.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Widgets/Text/SMultiLineEditableText.h"
+
+class ITextLayoutMarshaller;
+
+class SSimpleTemplateEditableText : public SMultiLineEditableText
+{
+	SLATE_BEGIN_ARGS(SSimpleTemplateEditableText)
+	{}
+		/** The initial text that will appear in the widget. */
+		SLATE_ATTRIBUTE(FText, Text)
+
+		/** The horizontal scroll bar widget */
+		SLATE_ARGUMENT(TSharedPtr< SScrollBar >, HScrollBar)
+
+		/** The vertical scroll bar widget */
+		SLATE_ARGUMENT(TSharedPtr< SScrollBar >, VScrollBar)
+
+		/** Called whenever the text is changed interactively by the user */
+		SLATE_EVENT(FOnTextChanged, OnTextChanged)
+
+		SLATE_END_ARGS()
+
+    void Construct( const FArguments& InArgs );
+
+protected:
+    virtual FReply OnKeyChar(const FGeometry& MyGeometry,const FCharacterEvent& InCharacterEvent) override;
+};

--- a/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditor.cpp
+++ b/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditor.cpp
@@ -1,0 +1,123 @@
+// Copyright Playspace S.L. 2017
+
+#include "SSimpleTemplateEditor.h"
+
+#include "Fonts/SlateFontInfo.h"
+#include "Internationalization/Text.h"
+#include "SimpleTemplate.h"
+#include "UObject/Class.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SGridPanel.h"
+#include "Widgets/Layout/SScrollBar.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Input/Reply.h"
+
+#include "SimpleTemplateEditorSettings.h"
+
+
+#define LOCTEXT_NAMESPACE "SSimpleTemplateEditor"
+
+
+/* SSimpleTemplateEditor interface
+ *****************************************************************************/
+
+SSimpleTemplateEditor::~SSimpleTemplateEditor()
+{
+	FCoreUObjectDelegates::OnObjectPropertyChanged.RemoveAll(this);
+}
+
+
+void SSimpleTemplateEditor::Construct(const FArguments& InArgs, USimpleTemplate* InSimpleTemplate, const TSharedRef<ISlateStyle>& InStyle)
+{
+	SimpleTemplate = InSimpleTemplate;
+
+	HorizontalScrollbar =
+		SNew(SScrollBar)
+		.Orientation(Orient_Horizontal)
+		.Thickness(FVector2D(10.0f, 10.0f));
+
+	VerticalScrollbar =
+		SNew(SScrollBar)
+		.Orientation(Orient_Vertical)
+		.Thickness(FVector2D(10.0f, 10.0f));
+
+	auto Settings = GetDefault<USimpleTemplateEditorSettings>();
+
+	ChildSlot
+	[
+		SNew(SBorder)
+		.BorderImage(FSimpleTemplateStyle::Get()->GetBrush("TextEditor.Border"))
+		[
+			SNew(SGridPanel)
+			.FillColumn(0, 1.0f)
+			.FillRow(0, 1.0f)
+			+SGridPanel::Slot(0, 0)
+			[
+				SAssignNew(EditableTextBox, SSimpleTemplateEditableText)
+				.Text(SimpleTemplate->Template)
+				.HScrollBar(HorizontalScrollbar)
+				.VScrollBar(VerticalScrollbar)
+				.OnTextChanged(this, &SSimpleTemplateEditor::HandleEditableTextBoxTextChanged)
+			]
+			+SGridPanel::Slot(1, 0)
+			[
+				VerticalScrollbar.ToSharedRef()
+			]
+			+SGridPanel::Slot(0, 1)
+			[
+				HorizontalScrollbar.ToSharedRef()
+			]
+		]
+	];
+
+	FCoreUObjectDelegates::OnObjectPropertyChanged.AddSP(this, &SSimpleTemplateEditor::HandleSimpleTemplatePropertyChanged);
+}
+
+
+void SSimpleTemplateEditor::GoTo(int32 LineNumber, int32 ColumnNumber)
+{
+	FTextLocation Location(LineNumber, ColumnNumber);
+	EditableTextBox->GoTo(Location);
+	EditableTextBox->ScrollTo(Location);
+	FSlateApplication::Get().SetKeyboardFocus(EditableTextBox.ToSharedRef());
+}
+
+
+/* SSimpleTemplateEditor callbacks
+ *****************************************************************************/
+
+void SSimpleTemplateEditor::HandleEditableTextBoxTextChanged(const FText& NewText)
+{
+	FText newText = EditableTextBox->GetText();
+	if (!newText.EqualTo(SimpleTemplate->Template))
+	{
+		SimpleTemplate->Template = newText;
+		SimpleTemplate->Status = ETemplateStatus::TS_Dirty;
+		SimpleTemplate->MarkPackageDirty();
+	}
+}
+
+	
+
+void SSimpleTemplateEditor::HandleEditableTextBoxTextCommitted(const FText& Comment, ETextCommit::Type CommitType)
+{
+	FText newText = EditableTextBox->GetText();
+	if (!newText.EqualTo(SimpleTemplate->Template))
+	{
+		SimpleTemplate->Template = newText;
+		SimpleTemplate->Status = ETemplateStatus::TS_Dirty;
+		SimpleTemplate->MarkPackageDirty();
+	}
+}
+
+
+void SSimpleTemplateEditor::HandleSimpleTemplatePropertyChanged(UObject* Object, FPropertyChangedEvent& PropertyChangedEvent)
+{
+	if (Object == SimpleTemplate)
+	{
+		EditableTextBox->SetText(SimpleTemplate->Template);
+	}
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditor.h
+++ b/Source/SimpleTemplateEditor/Private/Widgets/SSimpleTemplateEditor.h
@@ -1,0 +1,63 @@
+// Copyright Playspace S.L. 2017
+
+#pragma once
+
+#include "Templates/SharedPointer.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Widgets/SCompoundWidget.h"
+#include "SSimpleTemplateEditableText.h"
+
+class FText;
+class ISlateStyle;
+class USimpleTemplate;
+
+
+/**
+ * Implements the USimpleTemplate asset editor widget.
+ */
+class SSimpleTemplateEditor
+	: public SCompoundWidget
+{
+public:
+
+	SLATE_BEGIN_ARGS(SSimpleTemplateEditor) { }
+	SLATE_END_ARGS()
+
+public:
+
+	/** Virtual destructor. */
+	virtual ~SSimpleTemplateEditor();
+
+	/**
+	 * Construct this widget
+	 *
+	 * @param InArgs The declaration data for this widget.
+	 * @param InSimpleTemplate The USimpleTemplate asset to edit.
+	 * @param InStyleSet The style set to use.
+	 */
+	void Construct(const FArguments& InArgs, USimpleTemplate* InSimpleTemplate, const TSharedRef<ISlateStyle>& InStyle);
+
+	void GoTo(int32 LineNumber, int32 CharacterNumber);
+
+private:
+
+	/** Callback for text changes in the editable text box. */
+	void HandleEditableTextBoxTextChanged(const FText& NewText);
+
+	/** Callback for committed text in the editable text box. */
+	void HandleEditableTextBoxTextCommitted(const FText& Comment, ETextCommit::Type CommitType);
+
+	/** Callback for property changes in the Simple Template. */
+	void HandleSimpleTemplatePropertyChanged(UObject* Object, FPropertyChangedEvent& PropertyChangedEvent);
+
+private:
+
+	/** Holds the editable text box widget. */
+	TSharedPtr<SSimpleTemplateEditableText> EditableTextBox;
+
+	/** Pointer to the Simple Template that is being edited. */
+	USimpleTemplate* SimpleTemplate;
+
+	TSharedPtr<SScrollBar> HorizontalScrollbar;
+	TSharedPtr<SScrollBar> VerticalScrollbar;
+};

--- a/Source/SimpleTemplateEditor/SimpleTemplateEditor.Build.cs
+++ b/Source/SimpleTemplateEditor/SimpleTemplateEditor.Build.cs
@@ -1,0 +1,53 @@
+// Copyright Playspace S.L. 2017
+
+using UnrealBuildTool;
+
+public class SimpleTemplateEditor : ModuleRules
+{
+	public SimpleTemplateEditor(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		DynamicallyLoadedModuleNames.AddRange(
+			new string[] {
+				"AssetTools",
+				"MainFrame",
+//				"WorkspaceMenuStructure",
+			});
+
+		PrivateIncludePaths.AddRange(
+			new string[] {
+				"SimpleTemplateEditor/Private",
+				"SimpleTemplateEditor/Private/AssetTools",
+				"SimpleTemplateEditor/Private/Factories",
+				"SimpleTemplateEditor/Private/Shared",
+				"SimpleTemplateEditor/Private/Styles",
+				"SimpleTemplateEditor/Private/Toolkits",
+				"SimpleTemplateEditor/Private/Widgets",
+			});
+
+		PrivateDependencyModuleNames.AddRange(
+			new string[] {
+				"ContentBrowser",
+				"Core",
+				"CoreUObject",
+				"DesktopWidgets",
+				"EditorStyle",
+				"Engine",
+				"InputCore",
+				"Projects",
+				"Slate",
+				"SlateCore",
+				"SimpleTemplate",
+				"UnrealEd",
+                "DesktopPlatform"
+			});
+
+		PrivateIncludePathModuleNames.AddRange(
+			new string[] {
+				"AssetTools",
+				"UnrealEd",
+//				"WorkspaceMenuStructure",
+			});
+	}
+}


### PR DESCRIPTION
* Moving template logic to own plugin

* Adding clean editor and asset

* Adding compile and serialize methods for template

* Import template from text file

* Fixing some missing name issues

* Adding export option form context menu, missing tool bar and error reporting

* Adding compile error view

* Working on template editor

* Adding compile, export and import toolbar buttons

* Adding compile action and working on output

* Template asset working!

* Adding dirty and template state

* Working on templates! Editor is working! Need to finish the compile process and the 'RUN' method with data

* Adding asset icons

* Refactoring token serialization

* Serialization done!

* Adding parsing tokens into tree

* Adding token serialization

* Save after successful compile

* Let the user use the tab key

* Getting rid of the need for RTTI (should be done using shared ptr static cast though) and adding first Interpet steps

* Working on interpretation of the compiled tenmplates

* Adding interpreter class

* Adding interpreter

* Template engine should be all up! Now the tests

* Ensure templates can compile in runtime

* Adding initial kismet hooks

* Adding template data provider

* Adding template data provider and interface to add custom providers

* Working on final compiler tweaks

* Adding first help and usage stuff